### PR TITLE
Fix lint

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -5,4 +5,4 @@ linters: with_defaults(
     cyclocomp_linter = NULL
     )
 # This should work but does not
-exclusions: list("R/cpp11.R")
+exclusions: list("R/cpp11.R", "tests/testthat.R")

--- a/.lintr
+++ b/.lintr
@@ -4,5 +4,4 @@ linters: with_defaults(
     todo_comment_linter = NULL,
     cyclocomp_linter = NULL
     )
-# This should work but does not
 exclusions: list("R/cpp11.R", "tests/testthat.R")


### PR DESCRIPTION
* The C++ linting now disabled on in codefactor.io (see https://www.codefactor.io/repository/github/mrc-ide/sircovid2/settings)
* Lintr configuration error fixed
* Adds tests/testthat.R to the exclude list