### PR TITLE
i20: Include index for model runs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid2
 Title: SIR Model for COVID-19
-Version: 0.5.6
+Version: 0.5.7
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/carehomes.R
+++ b/R/carehomes.R
@@ -97,7 +97,11 @@ carehomes_parameters <- function(start_date, region,
 ##'   in hospital, (5) total deaths, (6) cumulative confirmed
 ##'   admissions,(7) cumulative confirmed new admissions, (8)
 ##'   recovered pre seroconversion (15 - 64 year-olds only), (9)
-##'   recovered seronegative and (10) recovered seropositive.
+##'   recovered seronegative and (10) recovered seropositive, and with
+##'   element `state` containing the same values followed by 17 S
+##'   compartments (one per age group, then one for carehome workers
+##'   and carehome residents respectively) and 17 "cumulative
+##'   admission" compartments.
 ##'
 ##' @export
 ##' @examples
@@ -106,14 +110,26 @@ carehomes_parameters <- function(start_date, region,
 ##' carehomes_index(mod$info())
 carehomes_index <- function(info) {
   index <- info$index
-  list(run = c(icu = index[["I_ICU_tot"]],
-               general = index[["general_tot"]],
-               deaths_comm = index[["D_comm_tot"]],
-               deaths_hosp = index[["D_hosp_tot"]],
-               deaths_tot = index[["D_tot"]],
-               admitted = index[["cum_admit_conf"]],
-               new = index[["cum_new_conf"]],
-               prob_pos = index[["prob_pos"]]))
+
+  ## Variables required for the particle filter to run:
+  index_run <- c(icu = index[["I_ICU_tot"]],
+                 general = index[["general_tot"]],
+                 deaths_comm = index[["D_comm_tot"]],
+                 deaths_hosp = index[["D_hosp_tot"]],
+                 deaths_tot = index[["D_tot"]],
+                 admitted = index[["cum_admit_conf"]],
+                 new = index[["cum_new_conf"]],
+                 prob_pos = index[["prob_pos"]])
+
+  ## Variables that we want to save for post-processing
+  suffix <- paste0("_", c(sircovid_age_bins()$start, "CHW", "CHR"))
+  index_S <- set_names(index[["S"]],
+                       paste0("S", suffix))
+  index_cum_admit <- set_names(index[["cum_admit_by_age"]],
+                               paste0("cum_admit", suffix))
+
+  list(run = index_run,
+       state = c(index_run, index_S, index_cum_admit))
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -80,3 +80,9 @@ as_date <- function(date) {
   }
   as.Date(date)
 }
+
+
+set_names <- function(x, nms) {
+  names(x) <- nms
+  x
+}

--- a/man/carehomes_index.Rd
+++ b/man/carehomes_index.Rd
@@ -16,7 +16,11 @@ order) (1) ICU, (2) general, (3) deaths in community, (4) deaths
 in hospital, (5) total deaths, (6) cumulative confirmed
 admissions,(7) cumulative confirmed new admissions, (8)
 recovered pre seroconversion (15 - 64 year-olds only), (9)
-recovered seronegative and (10) recovered seropositive.
+recovered seronegative and (10) recovered seropositive, and with
+element \code{state} containing the same values followed by 17 S
+compartments (one per age group, then one for carehome workers
+and carehome residents respectively) and 17 "cumulative
+admission" compartments.
 }
 \description{
 Index of "interesting" elements for the carehomes model. This function

--- a/tests/testthat/test-carehomes-support.R
+++ b/tests/testthat/test-carehomes-support.R
@@ -266,3 +266,15 @@ test_that("carehomes_population preserves population", {
   expect_equal(res[1:5], population[1:5])
   expect_true(all(res[6:17] < population[6:17]))
 })
+
+
+test_that("carehomes_index returns S compartments", {
+  p <- carehomes_parameters(sircovid_date("2020-02-07"), "england")
+  mod <- carehomes$new(p, 0, 5, seed = 1L)
+  index <- carehomes_index(mod$info())
+  expect_equal(
+    unname(index$state),
+    c(unname(index$run),
+      mod$info()$index$S,
+      mod$info()$index$cum_admit_by_age))
+})


### PR DESCRIPTION
This PR adds support for filtering during state collection (projections and pmcmc). Collects all scalar variables as used in the fitting, along with age-structured S and cumulative incidence.

Fixes #20 