### PR TITLE
adding pillar 2 testing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid2
 Title: SIR Model for COVID-19
-Version: 0.5.12
+Version: 0.5.13
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/carehomes.R
+++ b/R/carehomes.R
@@ -115,10 +115,10 @@ carehomes_parameters <- function(start_date, region,
 ##'   order) (1) ICU, (2) general, (3) deaths in community, (4) deaths
 ##'   in hospital, (5) total deaths, (6) cumulative confirmed
 ##'   admissions,(7) cumulative confirmed new admissions, (8)
-##'   probability of a positive sero test, (9) probability of a positive 
-##'   pillar 2 test, and with element `state` containing the same values 
-##'   followed by 17 S compartments (one per age group, then one for 
-##'   carehome workers and carehome residents respectively) and 17 
+##'   probability of a positive sero test, (9) probability of a positive
+##'   pillar 2 test, and with element `state` containing the same values
+##'   followed by 17 S compartments (one per age group, then one for
+##'   carehome workers and carehome residents respectively) and 17
 ##'   "cumulative admission" compartments.
 ##'
 ##' @export
@@ -240,7 +240,7 @@ carehomes_compare <- function(state, prev_state, observed, pars) {
   ll_serology <- ll_binom(observed$npos_15_64,
                           observed$ntot_15_64,
                           model_sero_prob_pos)
-  
+
   ll_pillar2 <- ll_binom(observed$pillar2_pos,
                          observed$pillar2_tot,
                          pars$phi_pillar2 * model_pillar2_prob_pos)

--- a/R/carehomes.R
+++ b/R/carehomes.R
@@ -115,12 +115,11 @@ carehomes_parameters <- function(start_date, region,
 ##'   order) (1) ICU, (2) general, (3) deaths in community, (4) deaths
 ##'   in hospital, (5) total deaths, (6) cumulative confirmed
 ##'   admissions,(7) cumulative confirmed new admissions, (8)
-##'   recovered pre seroconversion (15 - 64 year-olds only), (9)
-##'   recovered seronegative and (10) recovered seropositive, and with
-##'   element `state` containing the same values followed by 17 S
-##'   compartments (one per age group, then one for carehome workers
-##'   and carehome residents respectively) and 17 "cumulative
-##'   admission" compartments.
+##'   probability of a positive sero test, (9) probability of a positive 
+##'   pillar 2 test, and with element `state` containing the same values 
+##'   followed by 17 S compartments (one per age group, then one for 
+##'   carehome workers and carehome residents respectively) and 17 
+##'   "cumulative admission" compartments.
 ##'
 ##' @export
 ##' @examples
@@ -137,7 +136,8 @@ carehomes_index <- function(info) {
                  deaths_hosp = index[["D_hosp_tot"]],
                  admitted = index[["cum_admit_conf"]],
                  new = index[["cum_new_conf"]],
-                 prob_pos = index[["prob_pos"]])
+                 sero_prob_pos = index[["sero_prob_pos"]],
+                 pillar2_prob_pos = index[["pillar2_prob_pos"]])
 
   ## Variables that we want to save for post-processing
   index_save <- c(hosp = index[["hosp_tot"]],
@@ -176,7 +176,9 @@ carehomes_index <- function(info) {
 ##'   nations - if given then `deaths_hosp` and `deaths_comm` must be
 ##'   `NA`), `admitted` (hospital admissions), `new` (new cases),
 ##'   `npos_15_64` (number of people seropositive in ages 15-64) and
-##'   `ntot_15_64` (number of people tested in ages 15-64).
+##'   `ntot_15_64` (number of people tested in ages 15-64), `pillar2_pos`
+##'   (number of pillar 2 positives), `pillar2_tot` (number of pillar 2
+##'   tests)
 ##'
 ##'
 ##' @param pars A list of parameters, as created by
@@ -200,7 +202,8 @@ carehomes_compare <- function(state, prev_state, observed, pars) {
   model_deaths_hosp <- state["deaths_hosp", ] - prev_state["deaths_hosp", ]
   model_admitted <- state["admitted", ] - prev_state["admitted", ]
   model_new <- state["new", ] - prev_state["new", ]
-  model_prob_pos <- state["prob_pos", ]
+  model_sero_prob_pos <- state["sero_prob_pos", ]
+  model_pillar2_prob_pos <- state["pillar2_prob_pos", ]
 
   pars <- pars$observation
   exp_noise <- pars$exp_noise
@@ -229,14 +232,18 @@ carehomes_compare <- function(state, prev_state, observed, pars) {
                       pars$k_new, exp_noise)
 
   ## Note we do not use exp_noise here as the only circumstances in
-  ## which a zero probability can be produced are when model_prob_pos
+  ## which a zero probability can be produced are when model_sero_prob_pos
   ## = 1 and there are some negative tests, or when model_prob_pos = 0
   ## and there are some positive tests. Such circumstances can only
   ## arise with extreme (0%/100%) specificity or sensitivity, which is
   ## wholly unrealistic.
   ll_serology <- ll_binom(observed$npos_15_64,
                           observed$ntot_15_64,
-                          model_prob_pos)
+                          model_sero_prob_pos)
+  
+  ll_pillar2 <- ll_binom(observed$pillar2_pos,
+                         observed$pillar2_tot,
+                         pars$phi_pillar2 * model_pillar2_prob_pos)
 
   ll_icu + ll_general + ll_deaths_hosp + ll_deaths_comm + ll_deaths +
     ll_admitted + ll_new + ll_serology
@@ -444,6 +451,8 @@ carehomes_parameters_observation <- function(exp_noise) {
     ## Daily new inpatient diagnoses
     phi_new = 1,
     k_new = 2,
+    ## Pillar 2 testing
+    phi_pillar2 = 10,
     ## rate for exponential noise, generally something big so noise is
     ## small (but non-zero))
     exp_noise = exp_noise)

--- a/inst/dust/carehomes.cpp
+++ b/inst/dust/carehomes.cpp
@@ -34,11 +34,6 @@ public:
     real_t comm_D_transmission;
     std::vector<real_t> delta_D_comm;
     std::vector<real_t> delta_D_hosp;
-    std::vector<real_t> delta_E;
-    std::vector<real_t> delta_I_asympt;
-    std::vector<real_t> delta_I_comm_D;
-    std::vector<real_t> delta_I_ILI;
-    std::vector<real_t> delta_I_mild;
     std::vector<real_t> delta_PCR_pos;
     std::vector<real_t> delta_R;
     std::vector<real_t> delta_R_neg;
@@ -143,31 +138,6 @@ public:
     int_t dim_D_hosp;
     int_t dim_delta_D_comm;
     int_t dim_delta_D_hosp;
-    int_t dim_delta_E;
-    int_t dim_delta_E_1;
-    int_t dim_delta_E_12;
-    int_t dim_delta_E_2;
-    int_t dim_delta_E_3;
-    int_t dim_delta_I_asympt;
-    int_t dim_delta_I_asympt_1;
-    int_t dim_delta_I_asympt_12;
-    int_t dim_delta_I_asympt_2;
-    int_t dim_delta_I_asympt_3;
-    int_t dim_delta_I_comm_D;
-    int_t dim_delta_I_comm_D_1;
-    int_t dim_delta_I_comm_D_12;
-    int_t dim_delta_I_comm_D_2;
-    int_t dim_delta_I_comm_D_3;
-    int_t dim_delta_I_ILI;
-    int_t dim_delta_I_ILI_1;
-    int_t dim_delta_I_ILI_12;
-    int_t dim_delta_I_ILI_2;
-    int_t dim_delta_I_ILI_3;
-    int_t dim_delta_I_mild;
-    int_t dim_delta_I_mild_1;
-    int_t dim_delta_I_mild_12;
-    int_t dim_delta_I_mild_2;
-    int_t dim_delta_I_mild_3;
     int_t dim_delta_PCR_pos;
     int_t dim_delta_PCR_pos_1;
     int_t dim_delta_PCR_pos_2;
@@ -452,6 +422,21 @@ public:
     int_t dim_N_tot;
     int_t dim_new_D_comm;
     int_t dim_new_D_hosp;
+    int_t dim_new_E;
+    int_t dim_new_E_1;
+    int_t dim_new_E_12;
+    int_t dim_new_E_2;
+    int_t dim_new_E_3;
+    int_t dim_new_I_asympt;
+    int_t dim_new_I_asympt_1;
+    int_t dim_new_I_asympt_12;
+    int_t dim_new_I_asympt_2;
+    int_t dim_new_I_asympt_3;
+    int_t dim_new_I_comm_D;
+    int_t dim_new_I_comm_D_1;
+    int_t dim_new_I_comm_D_12;
+    int_t dim_new_I_comm_D_2;
+    int_t dim_new_I_comm_D_3;
     int_t dim_new_I_hosp_D_conf;
     int_t dim_new_I_hosp_D_conf_1;
     int_t dim_new_I_hosp_D_conf_12;
@@ -492,6 +477,16 @@ public:
     int_t dim_new_I_ICU_R_unconf_12;
     int_t dim_new_I_ICU_R_unconf_2;
     int_t dim_new_I_ICU_R_unconf_3;
+    int_t dim_new_I_ILI;
+    int_t dim_new_I_ILI_1;
+    int_t dim_new_I_ILI_12;
+    int_t dim_new_I_ILI_2;
+    int_t dim_new_I_ILI_3;
+    int_t dim_new_I_mild;
+    int_t dim_new_I_mild_1;
+    int_t dim_new_I_mild_12;
+    int_t dim_new_I_mild_2;
+    int_t dim_new_I_mild_3;
     int_t dim_new_I_triage_D_conf;
     int_t dim_new_I_triage_D_conf_1;
     int_t dim_new_I_triage_D_conf_12;
@@ -614,7 +609,7 @@ public:
     std::vector<real_t> initial_N_tot;
     real_t initial_N_tot2;
     std::vector<real_t> initial_PCR_pos;
-    real_t initial_prob_pos;
+    real_t initial_pillar2_prob_pos;
     std::vector<real_t> initial_R;
     std::vector<real_t> initial_R_neg;
     std::vector<real_t> initial_R_pos;
@@ -622,6 +617,7 @@ public:
     std::vector<real_t> initial_R_stepdown_conf;
     std::vector<real_t> initial_R_stepdown_unconf;
     std::vector<real_t> initial_S;
+    real_t initial_sero_prob_pos;
     real_t initial_time;
     std::vector<real_t> lambda;
     std::vector<real_t> m;
@@ -675,6 +671,9 @@ public:
     real_t N_tot_15_64;
     std::vector<real_t> new_D_comm;
     std::vector<real_t> new_D_hosp;
+    std::vector<real_t> new_E;
+    std::vector<real_t> new_I_asympt;
+    std::vector<real_t> new_I_comm_D;
     std::vector<real_t> new_I_hosp_D_conf;
     std::vector<real_t> new_I_hosp_D_unconf;
     std::vector<real_t> new_I_hosp_R_conf;
@@ -683,6 +682,8 @@ public:
     std::vector<real_t> new_I_ICU_D_unconf;
     std::vector<real_t> new_I_ICU_R_conf;
     std::vector<real_t> new_I_ICU_R_unconf;
+    std::vector<real_t> new_I_ILI;
+    std::vector<real_t> new_I_mild;
     std::vector<real_t> new_I_triage_D_conf;
     std::vector<real_t> new_I_triage_D_unconf;
     std::vector<real_t> new_I_triage_R_conf;
@@ -766,10 +767,10 @@ public:
   carehomes(const init_t& data): internal(data) {
   }
   size_t size() {
-    return 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf + internal.dim_I_ICU_D_unconf + internal.dim_I_ICU_D_conf;
+    return 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf + internal.dim_I_ICU_D_unconf + internal.dim_I_ICU_D_conf;
   }
   std::vector<real_t> initial(size_t step) {
-    std::vector<real_t> state(13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf + internal.dim_I_ICU_D_unconf + internal.dim_I_ICU_D_conf);
+    std::vector<real_t> state(14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf + internal.dim_I_ICU_D_unconf + internal.dim_I_ICU_D_conf);
     state[0] = internal.initial_time;
     state[1] = internal.initial_cum_infections;
     state[2] = internal.initial_cum_admit_conf;
@@ -782,8 +783,9 @@ public:
     state[9] = internal.initial_D_hosp_tot;
     state[10] = internal.initial_D_comm_tot;
     state[11] = internal.initial_D_tot;
-    state[12] = internal.initial_prob_pos;
-    std::copy(internal.initial_S.begin(), internal.initial_S.end(), state.begin() + 13);
+    state[12] = internal.initial_sero_prob_pos;
+    state[13] = internal.initial_pillar2_prob_pos;
+    std::copy(internal.initial_S.begin(), internal.initial_S.end(), state.begin() + 14);
     std::copy(internal.initial_R_pos.begin(), internal.initial_R_pos.end(), state.begin() + internal.offset_variable_R_pos);
     std::copy(internal.initial_R_neg.begin(), internal.initial_R_neg.end(), state.begin() + internal.offset_variable_R_neg);
     std::copy(internal.initial_R.begin(), internal.initial_R.end(), state.begin() + internal.offset_variable_R);
@@ -818,7 +820,7 @@ public:
   __device__
   #endif
   void update(size_t step, const real_t * state, dust::rng_state_t<real_t>& rng_state, real_t * state_next) {
-    const real_t * S = state + 13;
+    const real_t * S = state + 14;
     const real_t * E = state + internal.offset_variable_E;
     const real_t * I_asympt = state + internal.offset_variable_I_asympt;
     const real_t * I_mild = state + internal.offset_variable_I_mild;
@@ -849,6 +851,7 @@ public:
     const real_t cum_new_conf = state[3];
     const real_t * cum_admit_by_age = state + internal.offset_variable_cum_admit_by_age;
     const real_t cum_infections = state[1];
+    const real_t * N_tot = state + internal.offset_variable_N_tot;
     state_next[5] = odin_sum1(S, 0, internal.dim_S) + odin_sum1(R_pre, 0, internal.dim_R_pre) + odin_sum1(R_pos, 0, internal.dim_R_pos) + odin_sum1(R_neg, 0, internal.dim_R_neg) + odin_sum1(E, 0, internal.dim_E);
     state_next[0] = (step + 1) * internal.dt;
     real_t beta = (step >= internal.dim_beta_step ? internal.beta_step[internal.dim_beta_step - 1] : internal.beta_step[step + 1 - 1]);
@@ -1477,13 +1480,6 @@ public:
         }
       }
     }
-    for (int_t i = 1; i <= internal.dim_delta_I_asympt_1; ++i) {
-      for (int_t j = 1; j <= internal.dim_delta_I_asympt_2; ++j) {
-        for (int_t k = 1; k <= internal.dim_delta_I_asympt_3; ++k) {
-          internal.delta_I_asympt[i - 1 + internal.dim_delta_I_asympt_1 * (j - 1) + internal.dim_delta_I_asympt_12 * (k - 1)] = internal.aux_II_asympt[internal.dim_aux_II_asympt_12 * (k - 1) + internal.dim_aux_II_asympt_1 * (j - 1) + i - 1];
-        }
-      }
-    }
     for (int_t i = 1; i <= internal.dim_delta_R_neg; ++i) {
       internal.delta_R_neg[i - 1] = odin_sum2(internal.n_R_pre.data(), i - 1, i, 0, internal.dim_n_R_pre_2, internal.dim_n_R_pre_1) - internal.delta_R_pos[i - 1];
     }
@@ -1502,6 +1498,13 @@ public:
     }
     real_t new_D_comm_tot = odin_sum1(internal.new_D_comm.data(), 0, internal.dim_new_D_comm);
     real_t new_D_hosp_tot = odin_sum1(internal.new_D_hosp.data(), 0, internal.dim_new_D_hosp);
+    for (int_t i = 1; i <= internal.dim_new_I_asympt_1; ++i) {
+      for (int_t j = 1; j <= internal.dim_new_I_asympt_2; ++j) {
+        for (int_t k = 1; k <= internal.dim_new_I_asympt_3; ++k) {
+          internal.new_I_asympt[i - 1 + internal.dim_new_I_asympt_1 * (j - 1) + internal.dim_new_I_asympt_12 * (k - 1)] = I_asympt[internal.dim_I_asympt_12 * (k - 1) + internal.dim_I_asympt_1 * (j - 1) + i - 1] + internal.aux_II_asympt[internal.dim_aux_II_asympt_12 * (k - 1) + internal.dim_aux_II_asympt_1 * (j - 1) + i - 1];
+        }
+      }
+    }
     for (int_t i = 1; i <= internal.dim_new_I_ICU_D_conf_1; ++i) {
       for (int_t j = 1; j <= internal.dim_new_I_ICU_D_conf_2; ++j) {
         for (int_t k = 1; k <= internal.dim_new_I_ICU_D_conf_3; ++k) {
@@ -1578,26 +1581,26 @@ public:
         }
       }
     }
-    for (int_t i = 1; i <= internal.dim_delta_I_comm_D_1; ++i) {
-      for (int_t j = 1; j <= internal.dim_delta_I_comm_D_2; ++j) {
-        for (int_t k = 1; k <= internal.dim_delta_I_comm_D_3; ++k) {
-          internal.delta_I_comm_D[i - 1 + internal.dim_delta_I_comm_D_1 * (j - 1) + internal.dim_delta_I_comm_D_12 * (k - 1)] = internal.aux_II_comm_D[internal.dim_aux_II_comm_D_12 * (k - 1) + internal.dim_aux_II_comm_D_1 * (j - 1) + i - 1];
-        }
-      }
-    }
-    for (int_t i = 1; i <= internal.dim_delta_I_mild_1; ++i) {
-      for (int_t j = 1; j <= internal.dim_delta_I_mild_2; ++j) {
-        for (int_t k = 1; k <= internal.dim_delta_I_mild_3; ++k) {
-          internal.delta_I_mild[i - 1 + internal.dim_delta_I_mild_1 * (j - 1) + internal.dim_delta_I_mild_12 * (k - 1)] = internal.aux_II_mild[internal.dim_aux_II_mild_12 * (k - 1) + internal.dim_aux_II_mild_1 * (j - 1) + i - 1];
-        }
-      }
-    }
     for (int_t i = 1; i <= internal.dim_n_ILI_to_triage_1; ++i) {
       for (int_t j = 1; j <= internal.dim_n_ILI_to_triage_2; ++j) {
         internal.n_ILI_to_triage[i - 1 + internal.dim_n_ILI_to_triage_1 * (j - 1)] = dust::distr::rbinom(rng_state, std::round(internal.n_ILI_to_hosp[internal.dim_n_ILI_to_hosp_1 * (j - 1) + i - 1]), internal.p_ICU_hosp[i - 1]);
       }
     }
+    for (int_t i = 1; i <= internal.dim_new_I_comm_D_1; ++i) {
+      for (int_t j = 1; j <= internal.dim_new_I_comm_D_2; ++j) {
+        for (int_t k = 1; k <= internal.dim_new_I_comm_D_3; ++k) {
+          internal.new_I_comm_D[i - 1 + internal.dim_new_I_comm_D_1 * (j - 1) + internal.dim_new_I_comm_D_12 * (k - 1)] = I_comm_D[internal.dim_I_comm_D_12 * (k - 1) + internal.dim_I_comm_D_1 * (j - 1) + i - 1] + internal.aux_II_comm_D[internal.dim_aux_II_comm_D_12 * (k - 1) + internal.dim_aux_II_comm_D_1 * (j - 1) + i - 1];
+        }
+      }
+    }
     real_t new_I_ICU_tot = odin_sum1(internal.new_I_ICU_R_conf.data(), 0, internal.dim_new_I_ICU_R_conf) + odin_sum1(internal.new_I_ICU_D_conf.data(), 0, internal.dim_new_I_ICU_D_conf);
+    for (int_t i = 1; i <= internal.dim_new_I_mild_1; ++i) {
+      for (int_t j = 1; j <= internal.dim_new_I_mild_2; ++j) {
+        for (int_t k = 1; k <= internal.dim_new_I_mild_3; ++k) {
+          internal.new_I_mild[i - 1 + internal.dim_new_I_mild_1 * (j - 1) + internal.dim_new_I_mild_12 * (k - 1)] = I_mild[internal.dim_I_mild_12 * (k - 1) + internal.dim_I_mild_1 * (j - 1) + i - 1] + internal.aux_II_mild[internal.dim_aux_II_mild_12 * (k - 1) + internal.dim_aux_II_mild_1 * (j - 1) + i - 1];
+        }
+      }
+    }
     for (int_t i = 1; i <= internal.dim_new_R_neg; ++i) {
       internal.new_R_neg[i - 1] = R_neg[i - 1] + internal.delta_R_neg[i - 1];
     }
@@ -1613,7 +1616,7 @@ public:
     for (int_t i = 1; i <= internal.dim_I_asympt_1; ++i) {
       for (int_t j = 1; j <= internal.dim_I_asympt_2; ++j) {
         for (int_t k = 1; k <= internal.dim_I_asympt_3; ++k) {
-          state_next[internal.offset_variable_I_asympt + i - 1 + internal.dim_I_asympt_1 * (j - 1) + internal.dim_I_asympt_12 * (k - 1)] = I_asympt[internal.dim_I_asympt_12 * (k - 1) + internal.dim_I_asympt_1 * (j - 1) + i - 1] + internal.delta_I_asympt[internal.dim_delta_I_asympt_12 * (k - 1) + internal.dim_delta_I_asympt_1 * (j - 1) + i - 1];
+          state_next[internal.offset_variable_I_asympt + i - 1 + internal.dim_I_asympt_1 * (j - 1) + internal.dim_I_asympt_12 * (k - 1)] = internal.new_I_asympt[internal.dim_new_I_asympt_12 * (k - 1) + internal.dim_new_I_asympt_1 * (j - 1) + i - 1];
         }
       }
     }
@@ -1658,13 +1661,6 @@ public:
         state_next[internal.offset_variable_R_stepdown_unconf + i - 1 + internal.dim_R_stepdown_unconf_1 * (j - 1)] = internal.new_R_stepdown_unconf[internal.dim_new_R_stepdown_unconf_1 * (j - 1) + i - 1];
       }
     }
-    for (int_t i = 1; i <= internal.dim_delta_I_ILI_1; ++i) {
-      for (int_t j = 1; j <= internal.dim_delta_I_ILI_2; ++j) {
-        for (int_t k = 1; k <= internal.dim_delta_I_ILI_3; ++k) {
-          internal.delta_I_ILI[i - 1 + internal.dim_delta_I_ILI_1 * (j - 1) + internal.dim_delta_I_ILI_12 * (k - 1)] = internal.aux_II_ILI[internal.dim_aux_II_ILI_12 * (k - 1) + internal.dim_aux_II_ILI_1 * (j - 1) + i - 1];
-        }
-      }
-    }
     for (int_t i = 1; i <= internal.dim_n_hosp_non_ICU_1; ++i) {
       for (int_t j = 1; j <= internal.dim_n_hosp_non_ICU_2; ++j) {
         internal.n_hosp_non_ICU[i - 1 + internal.dim_n_hosp_non_ICU_1 * (j - 1)] = internal.n_ILI_to_hosp[internal.dim_n_ILI_to_hosp_1 * (j - 1) + i - 1] - internal.n_ILI_to_triage[internal.dim_n_ILI_to_triage_1 * (j - 1) + i - 1];
@@ -1678,10 +1674,17 @@ public:
     for (int_t i = 1; i <= internal.dim_n_SE; ++i) {
       internal.n_SE[i - 1] = dust::distr::rbinom(rng_state, std::round(S[i - 1]), internal.p_SE[i - 1]);
     }
+    for (int_t i = 1; i <= internal.dim_new_I_ILI_1; ++i) {
+      for (int_t j = 1; j <= internal.dim_new_I_ILI_2; ++j) {
+        for (int_t k = 1; k <= internal.dim_new_I_ILI_3; ++k) {
+          internal.new_I_ILI[i - 1 + internal.dim_new_I_ILI_1 * (j - 1) + internal.dim_new_I_ILI_12 * (k - 1)] = I_ILI[internal.dim_I_ILI_12 * (k - 1) + internal.dim_I_ILI_1 * (j - 1) + i - 1] + internal.aux_II_ILI[internal.dim_aux_II_ILI_12 * (k - 1) + internal.dim_aux_II_ILI_1 * (j - 1) + i - 1];
+        }
+      }
+    }
     for (int_t i = 1; i <= internal.dim_I_comm_D_1; ++i) {
       for (int_t j = 1; j <= internal.dim_I_comm_D_2; ++j) {
         for (int_t k = 1; k <= internal.dim_I_comm_D_3; ++k) {
-          state_next[internal.offset_variable_I_comm_D + i - 1 + internal.dim_I_comm_D_1 * (j - 1) + internal.dim_I_comm_D_12 * (k - 1)] = I_comm_D[internal.dim_I_comm_D_12 * (k - 1) + internal.dim_I_comm_D_1 * (j - 1) + i - 1] + internal.delta_I_comm_D[internal.dim_delta_I_comm_D_12 * (k - 1) + internal.dim_delta_I_comm_D_1 * (j - 1) + i - 1];
+          state_next[internal.offset_variable_I_comm_D + i - 1 + internal.dim_I_comm_D_1 * (j - 1) + internal.dim_I_comm_D_12 * (k - 1)] = internal.new_I_comm_D[internal.dim_new_I_comm_D_12 * (k - 1) + internal.dim_new_I_comm_D_1 * (j - 1) + i - 1];
         }
       }
     }
@@ -1689,14 +1692,14 @@ public:
     for (int_t i = 1; i <= internal.dim_I_mild_1; ++i) {
       for (int_t j = 1; j <= internal.dim_I_mild_2; ++j) {
         for (int_t k = 1; k <= internal.dim_I_mild_3; ++k) {
-          state_next[internal.offset_variable_I_mild + i - 1 + internal.dim_I_mild_1 * (j - 1) + internal.dim_I_mild_12 * (k - 1)] = I_mild[internal.dim_I_mild_12 * (k - 1) + internal.dim_I_mild_1 * (j - 1) + i - 1] + internal.delta_I_mild[internal.dim_delta_I_mild_12 * (k - 1) + internal.dim_delta_I_mild_1 * (j - 1) + i - 1];
+          state_next[internal.offset_variable_I_mild + i - 1 + internal.dim_I_mild_1 * (j - 1) + internal.dim_I_mild_12 * (k - 1)] = internal.new_I_mild[internal.dim_new_I_mild_12 * (k - 1) + internal.dim_new_I_mild_1 * (j - 1) + i - 1];
         }
       }
     }
-    state_next[12] = odin_sum1(internal.new_R_pos.data(), 3, 13) / (real_t) internal.N_tot_15_64 + (1 - internal.p_specificity) * (1 - (odin_sum2(internal.new_R_pre.data(), 3, 13, 0, internal.dim_new_R_pre_2, internal.dim_new_R_pre_1) + odin_sum1(internal.new_R_neg.data(), 3, 13) + odin_sum1(internal.new_R_pos.data(), 3, 13)) / (real_t) internal.N_tot_15_64);
     for (int_t i = 1; i <= internal.dim_R_neg; ++i) {
       state_next[internal.offset_variable_R_neg + i - 1] = internal.new_R_neg[i - 1];
     }
+    state_next[12] = odin_sum1(internal.new_R_pos.data(), 3, 13) / (real_t) internal.N_tot_15_64 + (1 - internal.p_specificity) * (1 - (odin_sum2(internal.new_R_pre.data(), 3, 13, 0, internal.dim_new_R_pre_2, internal.dim_new_R_pre_1) + odin_sum1(internal.new_R_neg.data(), 3, 13) + odin_sum1(internal.new_R_pos.data(), 3, 13)) / (real_t) internal.N_tot_15_64);
     for (int_t i = 1; i <= internal.dim_aux_EE_1; ++i) {
       int_t j = 1;
       int_t k = 1;
@@ -1760,19 +1763,13 @@ public:
     for (int_t i = 1; i <= internal.dim_I_ILI_1; ++i) {
       for (int_t j = 1; j <= internal.dim_I_ILI_2; ++j) {
         for (int_t k = 1; k <= internal.dim_I_ILI_3; ++k) {
-          state_next[internal.offset_variable_I_ILI + i - 1 + internal.dim_I_ILI_1 * (j - 1) + internal.dim_I_ILI_12 * (k - 1)] = I_ILI[internal.dim_I_ILI_12 * (k - 1) + internal.dim_I_ILI_1 * (j - 1) + i - 1] + internal.delta_I_ILI[internal.dim_delta_I_ILI_12 * (k - 1) + internal.dim_delta_I_ILI_1 * (j - 1) + i - 1];
+          state_next[internal.offset_variable_I_ILI + i - 1 + internal.dim_I_ILI_1 * (j - 1) + internal.dim_I_ILI_12 * (k - 1)] = internal.new_I_ILI[internal.dim_new_I_ILI_12 * (k - 1) + internal.dim_new_I_ILI_1 * (j - 1) + i - 1];
         }
       }
     }
+    state_next[13] = (odin_sum1(internal.new_I_ILI.data(), 0, internal.dim_new_I_ILI) + odin_sum1(internal.new_I_mild.data(), 0, internal.dim_new_I_mild)) / (real_t) odin_sum1(N_tot, 0, internal.dim_N_tot);
     for (int_t i = 1; i <= internal.dim_S; ++i) {
-      state_next[13 + i - 1] = S[i - 1] - internal.n_SE[i - 1];
-    }
-    for (int_t i = 1; i <= internal.dim_delta_E_1; ++i) {
-      for (int_t j = 1; j <= internal.dim_delta_E_2; ++j) {
-        for (int_t k = 1; k <= internal.dim_delta_E_3; ++k) {
-          internal.delta_E[i - 1 + internal.dim_delta_E_1 * (j - 1) + internal.dim_delta_E_12 * (k - 1)] = internal.aux_EE[internal.dim_aux_EE_12 * (k - 1) + internal.dim_aux_EE_1 * (j - 1) + i - 1];
-        }
-      }
+      state_next[14 + i - 1] = S[i - 1] - internal.n_SE[i - 1];
     }
     for (int_t i = 1; i <= internal.dim_n_ILI_to_hosp_D_conf_1; ++i) {
       for (int_t j = 1; j <= internal.dim_n_ILI_to_hosp_D_conf_2; ++j) {
@@ -1787,6 +1784,13 @@ public:
     for (int_t i = 1; i <= internal.dim_n_ILI_to_triage_R_conf_1; ++i) {
       for (int_t j = 1; j <= internal.dim_n_ILI_to_triage_R_conf_2; ++j) {
         internal.n_ILI_to_triage_R_conf[i - 1 + internal.dim_n_ILI_to_triage_R_conf_1 * (j - 1)] = dust::distr::rbinom(rng_state, std::round(internal.n_ILI_to_triage_R[internal.dim_n_ILI_to_triage_R_1 * (j - 1) + i - 1]), internal.p_admit_conf[i - 1]);
+      }
+    }
+    for (int_t i = 1; i <= internal.dim_new_E_1; ++i) {
+      for (int_t j = 1; j <= internal.dim_new_E_2; ++j) {
+        for (int_t k = 1; k <= internal.dim_new_E_3; ++k) {
+          internal.new_E[i - 1 + internal.dim_new_E_1 * (j - 1) + internal.dim_new_E_12 * (k - 1)] = E[internal.dim_E_12 * (k - 1) + internal.dim_E_1 * (j - 1) + i - 1] + internal.aux_EE[internal.dim_aux_EE_12 * (k - 1) + internal.dim_aux_EE_1 * (j - 1) + i - 1];
+        }
       }
     }
     for (int_t i = 1; i <= internal.dim_new_I_triage_D_conf_1; ++i) {
@@ -1880,7 +1884,7 @@ public:
     for (int_t i = 1; i <= internal.dim_E_1; ++i) {
       for (int_t j = 1; j <= internal.dim_E_2; ++j) {
         for (int_t k = 1; k <= internal.dim_E_3; ++k) {
-          state_next[internal.offset_variable_E + i - 1 + internal.dim_E_1 * (j - 1) + internal.dim_E_12 * (k - 1)] = E[internal.dim_E_12 * (k - 1) + internal.dim_E_1 * (j - 1) + i - 1] + internal.delta_E[internal.dim_delta_E_12 * (k - 1) + internal.dim_delta_E_1 * (j - 1) + i - 1];
+          state_next[internal.offset_variable_E + i - 1 + internal.dim_E_1 * (j - 1) + internal.dim_E_12 * (k - 1)] = internal.new_E[internal.dim_new_E_12 * (k - 1) + internal.dim_new_E_1 * (j - 1) + i - 1];
         }
       }
     }
@@ -2246,7 +2250,8 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.initial_hosp_tot = 0;
   internal.initial_I_ICU_tot = 0;
   internal.initial_N_tot2 = 0;
-  internal.initial_prob_pos = 0;
+  internal.initial_pillar2_prob_pos = 0;
+  internal.initial_sero_prob_pos = 0;
   internal.initial_time = 0;
   internal.gamma_R_pre = std::vector<real_t>(internal.dim_gamma_R_pre);
   internal.comm_D_transmission = NA_REAL;
@@ -2386,21 +2391,6 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.dim_D_hosp = internal.N_age;
   internal.dim_delta_D_comm = internal.N_age;
   internal.dim_delta_D_hosp = internal.N_age;
-  internal.dim_delta_E_1 = internal.N_age;
-  internal.dim_delta_E_2 = internal.s_E;
-  internal.dim_delta_E_3 = internal.trans_classes;
-  internal.dim_delta_I_asympt_1 = internal.N_age;
-  internal.dim_delta_I_asympt_2 = internal.s_asympt;
-  internal.dim_delta_I_asympt_3 = internal.trans_classes;
-  internal.dim_delta_I_comm_D_1 = internal.N_age;
-  internal.dim_delta_I_comm_D_2 = internal.s_comm_D;
-  internal.dim_delta_I_comm_D_3 = internal.trans_classes;
-  internal.dim_delta_I_ILI_1 = internal.N_age;
-  internal.dim_delta_I_ILI_2 = internal.s_ILI;
-  internal.dim_delta_I_ILI_3 = internal.trans_classes;
-  internal.dim_delta_I_mild_1 = internal.N_age;
-  internal.dim_delta_I_mild_2 = internal.s_mild;
-  internal.dim_delta_I_mild_3 = internal.trans_classes;
   internal.dim_delta_PCR_pos_1 = internal.N_age;
   internal.dim_delta_PCR_pos_2 = internal.s_PCR_pos;
   internal.dim_delta_R = internal.N_age;
@@ -2579,6 +2569,15 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.dim_N_tot = internal.N_age;
   internal.dim_new_D_comm = internal.N_age;
   internal.dim_new_D_hosp = internal.N_age;
+  internal.dim_new_E_1 = internal.N_age;
+  internal.dim_new_E_2 = internal.s_E;
+  internal.dim_new_E_3 = internal.trans_classes;
+  internal.dim_new_I_asympt_1 = internal.N_age;
+  internal.dim_new_I_asympt_2 = internal.s_asympt;
+  internal.dim_new_I_asympt_3 = internal.trans_classes;
+  internal.dim_new_I_comm_D_1 = internal.N_age;
+  internal.dim_new_I_comm_D_2 = internal.s_comm_D;
+  internal.dim_new_I_comm_D_3 = internal.trans_classes;
   internal.dim_new_I_hosp_D_conf_1 = internal.N_age;
   internal.dim_new_I_hosp_D_conf_2 = internal.s_hosp_D;
   internal.dim_new_I_hosp_D_conf_3 = internal.trans_classes;
@@ -2603,6 +2602,12 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.dim_new_I_ICU_R_unconf_1 = internal.N_age;
   internal.dim_new_I_ICU_R_unconf_2 = internal.s_ICU_R;
   internal.dim_new_I_ICU_R_unconf_3 = internal.trans_classes;
+  internal.dim_new_I_ILI_1 = internal.N_age;
+  internal.dim_new_I_ILI_2 = internal.s_ILI;
+  internal.dim_new_I_ILI_3 = internal.trans_classes;
+  internal.dim_new_I_mild_1 = internal.N_age;
+  internal.dim_new_I_mild_2 = internal.s_mild;
+  internal.dim_new_I_mild_3 = internal.trans_classes;
   internal.dim_new_I_triage_D_conf_1 = internal.N_age;
   internal.dim_new_I_triage_D_conf_2 = internal.s_triage;
   internal.dim_new_I_triage_D_conf_3 = internal.trans_classes;
@@ -2724,16 +2729,6 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.dim_aux_p_bin = internal.dim_aux_p_bin_1 * internal.dim_aux_p_bin_2;
   internal.dim_aux_R_stepdown_conf = internal.dim_aux_R_stepdown_conf_1 * internal.dim_aux_R_stepdown_conf_2;
   internal.dim_aux_R_stepdown_unconf = internal.dim_aux_R_stepdown_unconf_1 * internal.dim_aux_R_stepdown_unconf_2;
-  internal.dim_delta_E = internal.dim_delta_E_1 * internal.dim_delta_E_2 * internal.dim_delta_E_3;
-  internal.dim_delta_E_12 = internal.dim_delta_E_1 * internal.dim_delta_E_2;
-  internal.dim_delta_I_asympt = internal.dim_delta_I_asympt_1 * internal.dim_delta_I_asympt_2 * internal.dim_delta_I_asympt_3;
-  internal.dim_delta_I_asympt_12 = internal.dim_delta_I_asympt_1 * internal.dim_delta_I_asympt_2;
-  internal.dim_delta_I_comm_D = internal.dim_delta_I_comm_D_1 * internal.dim_delta_I_comm_D_2 * internal.dim_delta_I_comm_D_3;
-  internal.dim_delta_I_comm_D_12 = internal.dim_delta_I_comm_D_1 * internal.dim_delta_I_comm_D_2;
-  internal.dim_delta_I_ILI = internal.dim_delta_I_ILI_1 * internal.dim_delta_I_ILI_2 * internal.dim_delta_I_ILI_3;
-  internal.dim_delta_I_ILI_12 = internal.dim_delta_I_ILI_1 * internal.dim_delta_I_ILI_2;
-  internal.dim_delta_I_mild = internal.dim_delta_I_mild_1 * internal.dim_delta_I_mild_2 * internal.dim_delta_I_mild_3;
-  internal.dim_delta_I_mild_12 = internal.dim_delta_I_mild_1 * internal.dim_delta_I_mild_2;
   internal.dim_delta_PCR_pos = internal.dim_delta_PCR_pos_1 * internal.dim_delta_PCR_pos_2;
   internal.dim_E = internal.dim_E_1 * internal.dim_E_2 * internal.dim_E_3;
   internal.dim_E_12 = internal.dim_E_1 * internal.dim_E_2;
@@ -2839,6 +2834,12 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.dim_n_R_stepdown_conf = internal.dim_n_R_stepdown_conf_1 * internal.dim_n_R_stepdown_conf_2;
   internal.dim_n_R_stepdown_unconf = internal.dim_n_R_stepdown_unconf_1 * internal.dim_n_R_stepdown_unconf_2;
   internal.dim_n_R_stepdown_unconf_to_conf = internal.dim_n_R_stepdown_unconf_to_conf_1 * internal.dim_n_R_stepdown_unconf_to_conf_2;
+  internal.dim_new_E = internal.dim_new_E_1 * internal.dim_new_E_2 * internal.dim_new_E_3;
+  internal.dim_new_E_12 = internal.dim_new_E_1 * internal.dim_new_E_2;
+  internal.dim_new_I_asympt = internal.dim_new_I_asympt_1 * internal.dim_new_I_asympt_2 * internal.dim_new_I_asympt_3;
+  internal.dim_new_I_asympt_12 = internal.dim_new_I_asympt_1 * internal.dim_new_I_asympt_2;
+  internal.dim_new_I_comm_D = internal.dim_new_I_comm_D_1 * internal.dim_new_I_comm_D_2 * internal.dim_new_I_comm_D_3;
+  internal.dim_new_I_comm_D_12 = internal.dim_new_I_comm_D_1 * internal.dim_new_I_comm_D_2;
   internal.dim_new_I_hosp_D_conf = internal.dim_new_I_hosp_D_conf_1 * internal.dim_new_I_hosp_D_conf_2 * internal.dim_new_I_hosp_D_conf_3;
   internal.dim_new_I_hosp_D_conf_12 = internal.dim_new_I_hosp_D_conf_1 * internal.dim_new_I_hosp_D_conf_2;
   internal.dim_new_I_hosp_D_unconf = internal.dim_new_I_hosp_D_unconf_1 * internal.dim_new_I_hosp_D_unconf_2 * internal.dim_new_I_hosp_D_unconf_3;
@@ -2855,6 +2856,10 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.dim_new_I_ICU_R_conf_12 = internal.dim_new_I_ICU_R_conf_1 * internal.dim_new_I_ICU_R_conf_2;
   internal.dim_new_I_ICU_R_unconf = internal.dim_new_I_ICU_R_unconf_1 * internal.dim_new_I_ICU_R_unconf_2 * internal.dim_new_I_ICU_R_unconf_3;
   internal.dim_new_I_ICU_R_unconf_12 = internal.dim_new_I_ICU_R_unconf_1 * internal.dim_new_I_ICU_R_unconf_2;
+  internal.dim_new_I_ILI = internal.dim_new_I_ILI_1 * internal.dim_new_I_ILI_2 * internal.dim_new_I_ILI_3;
+  internal.dim_new_I_ILI_12 = internal.dim_new_I_ILI_1 * internal.dim_new_I_ILI_2;
+  internal.dim_new_I_mild = internal.dim_new_I_mild_1 * internal.dim_new_I_mild_2 * internal.dim_new_I_mild_3;
+  internal.dim_new_I_mild_12 = internal.dim_new_I_mild_1 * internal.dim_new_I_mild_2;
   internal.dim_new_I_triage_D_conf = internal.dim_new_I_triage_D_conf_1 * internal.dim_new_I_triage_D_conf_2 * internal.dim_new_I_triage_D_conf_3;
   internal.dim_new_I_triage_D_conf_12 = internal.dim_new_I_triage_D_conf_1 * internal.dim_new_I_triage_D_conf_2;
   internal.dim_new_I_triage_D_unconf = internal.dim_new_I_triage_D_unconf_1 * internal.dim_new_I_triage_D_unconf_2 * internal.dim_new_I_triage_D_unconf_3;
@@ -2906,14 +2911,14 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   for (int_t i = 1; i <= internal.dim_S; ++i) {
     internal.initial_S[i - 1] = 0;
   }
-  internal.offset_variable_cum_admit_by_age = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm;
-  internal.offset_variable_D_comm = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp;
-  internal.offset_variable_D_hosp = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R;
-  internal.offset_variable_N_tot = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age;
-  internal.offset_variable_R = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg;
-  internal.offset_variable_R_neg = 13 + internal.dim_S + internal.dim_R_pos;
-  internal.offset_variable_R_pos = 13 + internal.dim_S;
-  internal.offset_variable_R_stepdown_unconf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot;
+  internal.offset_variable_cum_admit_by_age = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm;
+  internal.offset_variable_D_comm = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp;
+  internal.offset_variable_D_hosp = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R;
+  internal.offset_variable_N_tot = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age;
+  internal.offset_variable_R = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg;
+  internal.offset_variable_R_neg = 14 + internal.dim_S + internal.dim_R_pos;
+  internal.offset_variable_R_pos = 14 + internal.dim_S;
+  internal.offset_variable_R_stepdown_unconf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot;
   internal.p_admit_conf = user_get_array_fixed<real_t, 1>(user, "p_admit_conf", internal.p_admit_conf, {internal.dim_p_admit_conf}, NA_REAL, NA_REAL);
   internal.p_asympt = user_get_array_fixed<real_t, 1>(user, "p_asympt", internal.p_asympt, {internal.dim_p_asympt}, NA_REAL, NA_REAL);
   internal.p_death_comm = user_get_array_fixed<real_t, 1>(user, "p_death_comm", internal.p_death_comm, {internal.dim_p_death_comm}, NA_REAL, NA_REAL);
@@ -2943,11 +2948,6 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.aux_p_bin = std::vector<real_t>(internal.dim_aux_p_bin);
   internal.aux_R_stepdown_conf = std::vector<real_t>(internal.dim_aux_R_stepdown_conf);
   internal.aux_R_stepdown_unconf = std::vector<real_t>(internal.dim_aux_R_stepdown_unconf);
-  internal.delta_E = std::vector<real_t>(internal.dim_delta_E);
-  internal.delta_I_asympt = std::vector<real_t>(internal.dim_delta_I_asympt);
-  internal.delta_I_comm_D = std::vector<real_t>(internal.dim_delta_I_comm_D);
-  internal.delta_I_ILI = std::vector<real_t>(internal.dim_delta_I_ILI);
-  internal.delta_I_mild = std::vector<real_t>(internal.dim_delta_I_mild);
   internal.delta_PCR_pos = std::vector<real_t>(internal.dim_delta_PCR_pos);
   internal.I_with_diff_trans = std::vector<real_t>(internal.dim_I_with_diff_trans);
   internal.initial_E = std::vector<real_t>(internal.dim_E);
@@ -3016,6 +3016,9 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.n_R_stepdown_conf = std::vector<real_t>(internal.dim_n_R_stepdown_conf);
   internal.n_R_stepdown_unconf = std::vector<real_t>(internal.dim_n_R_stepdown_unconf);
   internal.n_R_stepdown_unconf_to_conf = std::vector<real_t>(internal.dim_n_R_stepdown_unconf_to_conf);
+  internal.new_E = std::vector<real_t>(internal.dim_new_E);
+  internal.new_I_asympt = std::vector<real_t>(internal.dim_new_I_asympt);
+  internal.new_I_comm_D = std::vector<real_t>(internal.dim_new_I_comm_D);
   internal.new_I_hosp_D_conf = std::vector<real_t>(internal.dim_new_I_hosp_D_conf);
   internal.new_I_hosp_D_unconf = std::vector<real_t>(internal.dim_new_I_hosp_D_unconf);
   internal.new_I_hosp_R_conf = std::vector<real_t>(internal.dim_new_I_hosp_R_conf);
@@ -3024,6 +3027,8 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.new_I_ICU_D_unconf = std::vector<real_t>(internal.dim_new_I_ICU_D_unconf);
   internal.new_I_ICU_R_conf = std::vector<real_t>(internal.dim_new_I_ICU_R_conf);
   internal.new_I_ICU_R_unconf = std::vector<real_t>(internal.dim_new_I_ICU_R_unconf);
+  internal.new_I_ILI = std::vector<real_t>(internal.dim_new_I_ILI);
+  internal.new_I_mild = std::vector<real_t>(internal.dim_new_I_mild);
   internal.new_I_triage_D_conf = std::vector<real_t>(internal.dim_new_I_triage_D_conf);
   internal.new_I_triage_D_unconf = std::vector<real_t>(internal.dim_new_I_triage_D_unconf);
   internal.new_I_triage_R_conf = std::vector<real_t>(internal.dim_new_I_triage_R_conf);
@@ -3175,26 +3180,26 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
     }
   }
   internal.m = user_get_array_fixed<real_t, 2>(user, "m", internal.m, {internal.dim_m_1, internal.dim_m_2}, NA_REAL, NA_REAL);
-  internal.offset_variable_E = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos;
-  internal.offset_variable_I_asympt = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E;
-  internal.offset_variable_I_comm_D = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI;
-  internal.offset_variable_I_hosp_D_conf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf;
-  internal.offset_variable_I_hosp_D_unconf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf;
-  internal.offset_variable_I_hosp_R_conf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf;
-  internal.offset_variable_I_hosp_R_unconf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf;
-  internal.offset_variable_I_ICU_D_conf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf + internal.dim_I_ICU_D_unconf;
-  internal.offset_variable_I_ICU_D_unconf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf;
-  internal.offset_variable_I_ICU_R_conf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf;
-  internal.offset_variable_I_ICU_R_unconf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf;
-  internal.offset_variable_I_ILI = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild;
-  internal.offset_variable_I_mild = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt;
-  internal.offset_variable_I_triage_D_conf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf;
-  internal.offset_variable_I_triage_D_unconf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf;
-  internal.offset_variable_I_triage_R_conf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf;
-  internal.offset_variable_I_triage_R_unconf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D;
-  internal.offset_variable_PCR_pos = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre;
-  internal.offset_variable_R_pre = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf;
-  internal.offset_variable_R_stepdown_conf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf;
+  internal.offset_variable_E = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos;
+  internal.offset_variable_I_asympt = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E;
+  internal.offset_variable_I_comm_D = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI;
+  internal.offset_variable_I_hosp_D_conf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf;
+  internal.offset_variable_I_hosp_D_unconf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf;
+  internal.offset_variable_I_hosp_R_conf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf;
+  internal.offset_variable_I_hosp_R_unconf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf;
+  internal.offset_variable_I_ICU_D_conf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf + internal.dim_I_ICU_D_unconf;
+  internal.offset_variable_I_ICU_D_unconf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf;
+  internal.offset_variable_I_ICU_R_conf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf;
+  internal.offset_variable_I_ICU_R_unconf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf;
+  internal.offset_variable_I_ILI = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild;
+  internal.offset_variable_I_mild = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt;
+  internal.offset_variable_I_triage_D_conf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf;
+  internal.offset_variable_I_triage_D_unconf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf;
+  internal.offset_variable_I_triage_R_conf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf;
+  internal.offset_variable_I_triage_R_unconf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D;
+  internal.offset_variable_PCR_pos = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre;
+  internal.offset_variable_R_pre = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf;
+  internal.offset_variable_R_stepdown_conf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf;
   for (int_t i = 1; i <= internal.dim_p_R_pre_1; ++i) {
     for (int_t j = 1; j <= internal.dim_p_R_pre_2; ++j) {
       internal.p_R_pre[i - 1 + internal.dim_p_R_pre_1 * (j - 1)] = 1 - std::exp(- internal.gamma_R_pre[j - 1] * internal.dt);
@@ -3223,8 +3228,8 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
 }
 template <>
 cpp11::sexp dust_info<carehomes>(const carehomes::init_t& internal) {
-  cpp11::writable::strings nms({"time", "cum_infections", "cum_admit_conf", "cum_new_conf", "beta_out", "N_tot2", "I_ICU_tot", "general_tot", "hosp_tot", "D_hosp_tot", "D_comm_tot", "D_tot", "prob_pos", "S", "R_pos", "R_neg", "R", "D_hosp", "D_comm", "cum_admit_by_age", "N_tot", "R_stepdown_unconf", "R_stepdown_conf", "R_pre", "PCR_pos", "E", "I_asympt", "I_mild", "I_ILI", "I_comm_D", "I_triage_R_unconf", "I_triage_R_conf", "I_triage_D_unconf", "I_triage_D_conf", "I_hosp_R_unconf", "I_hosp_R_conf", "I_hosp_D_unconf", "I_hosp_D_conf", "I_ICU_R_unconf", "I_ICU_R_conf", "I_ICU_D_unconf", "I_ICU_D_conf"});
-  cpp11::writable::list dim(42);
+  cpp11::writable::strings nms({"time", "cum_infections", "cum_admit_conf", "cum_new_conf", "beta_out", "N_tot2", "I_ICU_tot", "general_tot", "hosp_tot", "D_hosp_tot", "D_comm_tot", "D_tot", "sero_prob_pos", "pillar2_prob_pos", "S", "R_pos", "R_neg", "R", "D_hosp", "D_comm", "cum_admit_by_age", "N_tot", "R_stepdown_unconf", "R_stepdown_conf", "R_pre", "PCR_pos", "E", "I_asympt", "I_mild", "I_ILI", "I_comm_D", "I_triage_R_unconf", "I_triage_R_conf", "I_triage_D_unconf", "I_triage_D_conf", "I_hosp_R_unconf", "I_hosp_R_conf", "I_hosp_D_unconf", "I_hosp_D_conf", "I_ICU_R_unconf", "I_ICU_R_conf", "I_ICU_D_unconf", "I_ICU_D_conf"});
+  cpp11::writable::list dim(43);
   dim[0] = cpp11::writable::integers({1});
   dim[1] = cpp11::writable::integers({1});
   dim[2] = cpp11::writable::integers({1});
@@ -3238,37 +3243,38 @@ cpp11::sexp dust_info<carehomes>(const carehomes::init_t& internal) {
   dim[10] = cpp11::writable::integers({1});
   dim[11] = cpp11::writable::integers({1});
   dim[12] = cpp11::writable::integers({1});
-  dim[13] = cpp11::writable::integers({internal.dim_S});
-  dim[14] = cpp11::writable::integers({internal.dim_R_pos});
-  dim[15] = cpp11::writable::integers({internal.dim_R_neg});
-  dim[16] = cpp11::writable::integers({internal.dim_R});
-  dim[17] = cpp11::writable::integers({internal.dim_D_hosp});
-  dim[18] = cpp11::writable::integers({internal.dim_D_comm});
-  dim[19] = cpp11::writable::integers({internal.dim_cum_admit_by_age});
-  dim[20] = cpp11::writable::integers({internal.dim_N_tot});
-  dim[21] = cpp11::writable::integers({internal.dim_R_stepdown_unconf_1, internal.dim_R_stepdown_unconf_2});
-  dim[22] = cpp11::writable::integers({internal.dim_R_stepdown_conf_1, internal.dim_R_stepdown_conf_2});
-  dim[23] = cpp11::writable::integers({internal.dim_R_pre_1, internal.dim_R_pre_2});
-  dim[24] = cpp11::writable::integers({internal.dim_PCR_pos_1, internal.dim_PCR_pos_2});
-  dim[25] = cpp11::writable::integers({internal.dim_E_1, internal.dim_E_2, internal.dim_E_3});
-  dim[26] = cpp11::writable::integers({internal.dim_I_asympt_1, internal.dim_I_asympt_2, internal.dim_I_asympt_3});
-  dim[27] = cpp11::writable::integers({internal.dim_I_mild_1, internal.dim_I_mild_2, internal.dim_I_mild_3});
-  dim[28] = cpp11::writable::integers({internal.dim_I_ILI_1, internal.dim_I_ILI_2, internal.dim_I_ILI_3});
-  dim[29] = cpp11::writable::integers({internal.dim_I_comm_D_1, internal.dim_I_comm_D_2, internal.dim_I_comm_D_3});
-  dim[30] = cpp11::writable::integers({internal.dim_I_triage_R_unconf_1, internal.dim_I_triage_R_unconf_2, internal.dim_I_triage_R_unconf_3});
-  dim[31] = cpp11::writable::integers({internal.dim_I_triage_R_conf_1, internal.dim_I_triage_R_conf_2, internal.dim_I_triage_R_conf_3});
-  dim[32] = cpp11::writable::integers({internal.dim_I_triage_D_unconf_1, internal.dim_I_triage_D_unconf_2, internal.dim_I_triage_D_unconf_3});
-  dim[33] = cpp11::writable::integers({internal.dim_I_triage_D_conf_1, internal.dim_I_triage_D_conf_2, internal.dim_I_triage_D_conf_3});
-  dim[34] = cpp11::writable::integers({internal.dim_I_hosp_R_unconf_1, internal.dim_I_hosp_R_unconf_2, internal.dim_I_hosp_R_unconf_3});
-  dim[35] = cpp11::writable::integers({internal.dim_I_hosp_R_conf_1, internal.dim_I_hosp_R_conf_2, internal.dim_I_hosp_R_conf_3});
-  dim[36] = cpp11::writable::integers({internal.dim_I_hosp_D_unconf_1, internal.dim_I_hosp_D_unconf_2, internal.dim_I_hosp_D_unconf_3});
-  dim[37] = cpp11::writable::integers({internal.dim_I_hosp_D_conf_1, internal.dim_I_hosp_D_conf_2, internal.dim_I_hosp_D_conf_3});
-  dim[38] = cpp11::writable::integers({internal.dim_I_ICU_R_unconf_1, internal.dim_I_ICU_R_unconf_2, internal.dim_I_ICU_R_unconf_3});
-  dim[39] = cpp11::writable::integers({internal.dim_I_ICU_R_conf_1, internal.dim_I_ICU_R_conf_2, internal.dim_I_ICU_R_conf_3});
-  dim[40] = cpp11::writable::integers({internal.dim_I_ICU_D_unconf_1, internal.dim_I_ICU_D_unconf_2, internal.dim_I_ICU_D_unconf_3});
-  dim[41] = cpp11::writable::integers({internal.dim_I_ICU_D_conf_1, internal.dim_I_ICU_D_conf_2, internal.dim_I_ICU_D_conf_3});
+  dim[13] = cpp11::writable::integers({1});
+  dim[14] = cpp11::writable::integers({internal.dim_S});
+  dim[15] = cpp11::writable::integers({internal.dim_R_pos});
+  dim[16] = cpp11::writable::integers({internal.dim_R_neg});
+  dim[17] = cpp11::writable::integers({internal.dim_R});
+  dim[18] = cpp11::writable::integers({internal.dim_D_hosp});
+  dim[19] = cpp11::writable::integers({internal.dim_D_comm});
+  dim[20] = cpp11::writable::integers({internal.dim_cum_admit_by_age});
+  dim[21] = cpp11::writable::integers({internal.dim_N_tot});
+  dim[22] = cpp11::writable::integers({internal.dim_R_stepdown_unconf_1, internal.dim_R_stepdown_unconf_2});
+  dim[23] = cpp11::writable::integers({internal.dim_R_stepdown_conf_1, internal.dim_R_stepdown_conf_2});
+  dim[24] = cpp11::writable::integers({internal.dim_R_pre_1, internal.dim_R_pre_2});
+  dim[25] = cpp11::writable::integers({internal.dim_PCR_pos_1, internal.dim_PCR_pos_2});
+  dim[26] = cpp11::writable::integers({internal.dim_E_1, internal.dim_E_2, internal.dim_E_3});
+  dim[27] = cpp11::writable::integers({internal.dim_I_asympt_1, internal.dim_I_asympt_2, internal.dim_I_asympt_3});
+  dim[28] = cpp11::writable::integers({internal.dim_I_mild_1, internal.dim_I_mild_2, internal.dim_I_mild_3});
+  dim[29] = cpp11::writable::integers({internal.dim_I_ILI_1, internal.dim_I_ILI_2, internal.dim_I_ILI_3});
+  dim[30] = cpp11::writable::integers({internal.dim_I_comm_D_1, internal.dim_I_comm_D_2, internal.dim_I_comm_D_3});
+  dim[31] = cpp11::writable::integers({internal.dim_I_triage_R_unconf_1, internal.dim_I_triage_R_unconf_2, internal.dim_I_triage_R_unconf_3});
+  dim[32] = cpp11::writable::integers({internal.dim_I_triage_R_conf_1, internal.dim_I_triage_R_conf_2, internal.dim_I_triage_R_conf_3});
+  dim[33] = cpp11::writable::integers({internal.dim_I_triage_D_unconf_1, internal.dim_I_triage_D_unconf_2, internal.dim_I_triage_D_unconf_3});
+  dim[34] = cpp11::writable::integers({internal.dim_I_triage_D_conf_1, internal.dim_I_triage_D_conf_2, internal.dim_I_triage_D_conf_3});
+  dim[35] = cpp11::writable::integers({internal.dim_I_hosp_R_unconf_1, internal.dim_I_hosp_R_unconf_2, internal.dim_I_hosp_R_unconf_3});
+  dim[36] = cpp11::writable::integers({internal.dim_I_hosp_R_conf_1, internal.dim_I_hosp_R_conf_2, internal.dim_I_hosp_R_conf_3});
+  dim[37] = cpp11::writable::integers({internal.dim_I_hosp_D_unconf_1, internal.dim_I_hosp_D_unconf_2, internal.dim_I_hosp_D_unconf_3});
+  dim[38] = cpp11::writable::integers({internal.dim_I_hosp_D_conf_1, internal.dim_I_hosp_D_conf_2, internal.dim_I_hosp_D_conf_3});
+  dim[39] = cpp11::writable::integers({internal.dim_I_ICU_R_unconf_1, internal.dim_I_ICU_R_unconf_2, internal.dim_I_ICU_R_unconf_3});
+  dim[40] = cpp11::writable::integers({internal.dim_I_ICU_R_conf_1, internal.dim_I_ICU_R_conf_2, internal.dim_I_ICU_R_conf_3});
+  dim[41] = cpp11::writable::integers({internal.dim_I_ICU_D_unconf_1, internal.dim_I_ICU_D_unconf_2, internal.dim_I_ICU_D_unconf_3});
+  dim[42] = cpp11::writable::integers({internal.dim_I_ICU_D_conf_1, internal.dim_I_ICU_D_conf_2, internal.dim_I_ICU_D_conf_3});
   dim.names() = nms;
-  cpp11::writable::list index(42);
+  cpp11::writable::list index(43);
   index[0] = cpp11::writable::integers({1});
   index[1] = cpp11::writable::integers({2});
   index[2] = cpp11::writable::integers({3});
@@ -3282,35 +3288,36 @@ cpp11::sexp dust_info<carehomes>(const carehomes::init_t& internal) {
   index[10] = cpp11::writable::integers({11});
   index[11] = cpp11::writable::integers({12});
   index[12] = cpp11::writable::integers({13});
-  index[13] = integer_sequence(14, internal.dim_S);
-  index[14] = integer_sequence(internal.offset_variable_R_pos + 1, internal.dim_R_pos);
-  index[15] = integer_sequence(internal.offset_variable_R_neg + 1, internal.dim_R_neg);
-  index[16] = integer_sequence(internal.offset_variable_R + 1, internal.dim_R);
-  index[17] = integer_sequence(internal.offset_variable_D_hosp + 1, internal.dim_D_hosp);
-  index[18] = integer_sequence(internal.offset_variable_D_comm + 1, internal.dim_D_comm);
-  index[19] = integer_sequence(internal.offset_variable_cum_admit_by_age + 1, internal.dim_cum_admit_by_age);
-  index[20] = integer_sequence(internal.offset_variable_N_tot + 1, internal.dim_N_tot);
-  index[21] = integer_sequence(internal.offset_variable_R_stepdown_unconf + 1, internal.dim_R_stepdown_unconf);
-  index[22] = integer_sequence(internal.offset_variable_R_stepdown_conf + 1, internal.dim_R_stepdown_conf);
-  index[23] = integer_sequence(internal.offset_variable_R_pre + 1, internal.dim_R_pre);
-  index[24] = integer_sequence(internal.offset_variable_PCR_pos + 1, internal.dim_PCR_pos);
-  index[25] = integer_sequence(internal.offset_variable_E + 1, internal.dim_E);
-  index[26] = integer_sequence(internal.offset_variable_I_asympt + 1, internal.dim_I_asympt);
-  index[27] = integer_sequence(internal.offset_variable_I_mild + 1, internal.dim_I_mild);
-  index[28] = integer_sequence(internal.offset_variable_I_ILI + 1, internal.dim_I_ILI);
-  index[29] = integer_sequence(internal.offset_variable_I_comm_D + 1, internal.dim_I_comm_D);
-  index[30] = integer_sequence(internal.offset_variable_I_triage_R_unconf + 1, internal.dim_I_triage_R_unconf);
-  index[31] = integer_sequence(internal.offset_variable_I_triage_R_conf + 1, internal.dim_I_triage_R_conf);
-  index[32] = integer_sequence(internal.offset_variable_I_triage_D_unconf + 1, internal.dim_I_triage_D_unconf);
-  index[33] = integer_sequence(internal.offset_variable_I_triage_D_conf + 1, internal.dim_I_triage_D_conf);
-  index[34] = integer_sequence(internal.offset_variable_I_hosp_R_unconf + 1, internal.dim_I_hosp_R_unconf);
-  index[35] = integer_sequence(internal.offset_variable_I_hosp_R_conf + 1, internal.dim_I_hosp_R_conf);
-  index[36] = integer_sequence(internal.offset_variable_I_hosp_D_unconf + 1, internal.dim_I_hosp_D_unconf);
-  index[37] = integer_sequence(internal.offset_variable_I_hosp_D_conf + 1, internal.dim_I_hosp_D_conf);
-  index[38] = integer_sequence(internal.offset_variable_I_ICU_R_unconf + 1, internal.dim_I_ICU_R_unconf);
-  index[39] = integer_sequence(internal.offset_variable_I_ICU_R_conf + 1, internal.dim_I_ICU_R_conf);
-  index[40] = integer_sequence(internal.offset_variable_I_ICU_D_unconf + 1, internal.dim_I_ICU_D_unconf);
-  index[41] = integer_sequence(internal.offset_variable_I_ICU_D_conf + 1, internal.dim_I_ICU_D_conf);
+  index[13] = cpp11::writable::integers({14});
+  index[14] = integer_sequence(15, internal.dim_S);
+  index[15] = integer_sequence(internal.offset_variable_R_pos + 1, internal.dim_R_pos);
+  index[16] = integer_sequence(internal.offset_variable_R_neg + 1, internal.dim_R_neg);
+  index[17] = integer_sequence(internal.offset_variable_R + 1, internal.dim_R);
+  index[18] = integer_sequence(internal.offset_variable_D_hosp + 1, internal.dim_D_hosp);
+  index[19] = integer_sequence(internal.offset_variable_D_comm + 1, internal.dim_D_comm);
+  index[20] = integer_sequence(internal.offset_variable_cum_admit_by_age + 1, internal.dim_cum_admit_by_age);
+  index[21] = integer_sequence(internal.offset_variable_N_tot + 1, internal.dim_N_tot);
+  index[22] = integer_sequence(internal.offset_variable_R_stepdown_unconf + 1, internal.dim_R_stepdown_unconf);
+  index[23] = integer_sequence(internal.offset_variable_R_stepdown_conf + 1, internal.dim_R_stepdown_conf);
+  index[24] = integer_sequence(internal.offset_variable_R_pre + 1, internal.dim_R_pre);
+  index[25] = integer_sequence(internal.offset_variable_PCR_pos + 1, internal.dim_PCR_pos);
+  index[26] = integer_sequence(internal.offset_variable_E + 1, internal.dim_E);
+  index[27] = integer_sequence(internal.offset_variable_I_asympt + 1, internal.dim_I_asympt);
+  index[28] = integer_sequence(internal.offset_variable_I_mild + 1, internal.dim_I_mild);
+  index[29] = integer_sequence(internal.offset_variable_I_ILI + 1, internal.dim_I_ILI);
+  index[30] = integer_sequence(internal.offset_variable_I_comm_D + 1, internal.dim_I_comm_D);
+  index[31] = integer_sequence(internal.offset_variable_I_triage_R_unconf + 1, internal.dim_I_triage_R_unconf);
+  index[32] = integer_sequence(internal.offset_variable_I_triage_R_conf + 1, internal.dim_I_triage_R_conf);
+  index[33] = integer_sequence(internal.offset_variable_I_triage_D_unconf + 1, internal.dim_I_triage_D_unconf);
+  index[34] = integer_sequence(internal.offset_variable_I_triage_D_conf + 1, internal.dim_I_triage_D_conf);
+  index[35] = integer_sequence(internal.offset_variable_I_hosp_R_unconf + 1, internal.dim_I_hosp_R_unconf);
+  index[36] = integer_sequence(internal.offset_variable_I_hosp_R_conf + 1, internal.dim_I_hosp_R_conf);
+  index[37] = integer_sequence(internal.offset_variable_I_hosp_D_unconf + 1, internal.dim_I_hosp_D_unconf);
+  index[38] = integer_sequence(internal.offset_variable_I_hosp_D_conf + 1, internal.dim_I_hosp_D_conf);
+  index[39] = integer_sequence(internal.offset_variable_I_ICU_R_unconf + 1, internal.dim_I_ICU_R_unconf);
+  index[40] = integer_sequence(internal.offset_variable_I_ICU_R_conf + 1, internal.dim_I_ICU_R_conf);
+  index[41] = integer_sequence(internal.offset_variable_I_ICU_D_unconf + 1, internal.dim_I_ICU_D_unconf);
+  index[42] = integer_sequence(internal.offset_variable_I_ICU_D_conf + 1, internal.dim_I_ICU_D_conf);
   index.names() = nms;
   size_t len = internal.offset_variable_I_ICU_D_conf + internal.dim_I_ICU_D_conf;
   using namespace cpp11::literals;

--- a/inst/odin/carehomes.R
+++ b/inst/odin/carehomes.R
@@ -17,11 +17,11 @@ update(time) <- (step + 1) * dt
 
 ## Core equations for transitions between compartments:
 update(S[]) <- S[i] - n_SE[i]
-update(E[, , ]) <- E[i, j, k] + delta_E[i, j, k]
-update(I_asympt[, , ]) <- I_asympt[i, j, k] + delta_I_asympt[i, j, k]
-update(I_mild[, , ]) <- I_mild[i, j, k] + delta_I_mild[i, j, k]
-update(I_ILI[, , ]) <- I_ILI[i, j, k] + delta_I_ILI[i, j, k]
-update(I_comm_D[, , ]) <- I_comm_D[i, j, k] + delta_I_comm_D[i, j, k]
+update(E[, , ]) <- new_E[i, j, k]
+update(I_asympt[, , ]) <- new_I_asympt[i, j, k]
+update(I_mild[, , ]) <- new_I_mild[i, j, k]
+update(I_ILI[, , ]) <- new_I_ILI[i, j, k]
+update(I_comm_D[, , ]) <- new_I_comm_D[i, j, k]
 update(I_triage_R_unconf[, , ]) <- new_I_triage_R_unconf[i, j, k]
 update(I_triage_R_conf[, , ]) <- new_I_triage_R_conf[i, j, k]
 update(I_triage_D_unconf[, , ]) <- new_I_triage_D_unconf[i, j, k]
@@ -132,25 +132,25 @@ aux_EE[, 1, trans_classes] <-
 ## Work out the E->E transitions
 aux_EE[, 2:s_E, ] <- n_EE[i, j - 1, k]
 aux_EE[, 1:s_E, ] <- aux_EE[i, j, k] - n_EE[i, j, k]
-delta_E[, , ] <- aux_EE[i, j, k]
+new_E[, , ] <- E[i, j, k] + aux_EE[i, j, k]
 
 ## Work out the I_asympt->I_asympt transitions
 aux_II_asympt[, 1, ] <- n_EI_asympt[i, k]
 aux_II_asympt[, 2:s_asympt, ] <- n_II_asympt[i, j - 1, k]
 aux_II_asympt[, 1:s_asympt, ] <- aux_II_asympt[i, j, k] - n_II_asympt[i, j, k]
-delta_I_asympt[, , ] <- aux_II_asympt[i, j, k]
+new_I_asympt[, , ] <- I_asympt[i, j, k] + aux_II_asympt[i, j, k]
 
 ## Work out the I_mild->I_mild transitions
 aux_II_mild[, 1, ] <- n_EI_mild[i, k]
 aux_II_mild[, 2:s_mild, ] <- n_II_mild[i, j - 1, k]
 aux_II_mild[, 1:s_mild, ] <- aux_II_mild[i, j, k] - n_II_mild[i, j, k]
-delta_I_mild[, , ] <- aux_II_mild[i, j, k]
+new_I_mild[, , ] <- I_mild[i, j, k] + aux_II_mild[i, j, k]
 
 ## Work out the I_ILI->I_ILI transitions
 aux_II_ILI[, 1, ] <- n_EI_ILI[i, k]
 aux_II_ILI[, 2:s_ILI, ] <- n_II_ILI[i, j - 1, k]
 aux_II_ILI[, 1:s_ILI, ] <- aux_II_ILI[i, j, k] - n_II_ILI[i, j, k]
-delta_I_ILI[, , ] <- aux_II_ILI[i, j, k]
+new_I_ILI[, , ] <- I_ILI[i, j, k] + aux_II_ILI[i, j, k]
 
 ## Work out the flow from I_ILI -> R, comm_D, hosp
 n_ILI_to_R[, ] <- rbinom(n_II_ILI[i, s_ILI, j], 1 - p_hosp_ILI[i])
@@ -163,7 +163,7 @@ n_ILI_to_hosp[, ] <-
 aux_II_comm_D[, 1, ] <- n_ILI_to_comm_D[i, k]
 aux_II_comm_D[, 2:s_comm_D, ] <- n_II_comm_D[i, j - 1, k]
 aux_II_comm_D[, 1:s_comm_D, ] <- aux_II_comm_D[i, j, k] - n_II_comm_D[i, j, k]
-delta_I_comm_D[, , ] <- aux_II_comm_D[i, j, k]
+new_I_comm_D[, , ] <- I_comm_D[i, j, k] + aux_II_comm_D[i, j, k]
 
 ## Work out the split in hospitals between hosp_D, hosp_R, triage_R
 ## and triage_D
@@ -543,32 +543,32 @@ dim(S) <- N_age
 ## Vectors handling the E class
 dim(E) <- c(N_age, s_E, trans_classes)
 dim(aux_EE) <- c(N_age, s_E, trans_classes)
-dim(delta_E) <- c(N_age, s_E, trans_classes)
+dim(new_E) <- c(N_age, s_E, trans_classes)
 dim(n_EE) <- c(N_age, s_E, trans_classes)
 
 ## Vectors handling the I_asympt class
 dim(I_asympt) <- c(N_age, s_asympt, trans_classes)
 dim(aux_II_asympt) <- c(N_age, s_asympt, trans_classes)
-dim(delta_I_asympt) <- c(N_age, s_asympt, trans_classes)
+dim(new_I_asympt) <- c(N_age, s_asympt, trans_classes)
 dim(n_II_asympt) <- c(N_age, s_asympt, trans_classes)
 
 ## Vectors handling the I_mild class
 dim(I_mild) <- c(N_age, s_mild, trans_classes)
 dim(aux_II_mild) <- c(N_age, s_mild, trans_classes)
-dim(delta_I_mild) <- c(N_age, s_mild, trans_classes)
+dim(new_I_mild) <- c(N_age, s_mild, trans_classes)
 dim(n_II_mild) <- c(N_age, s_mild, trans_classes)
 
 ## Vectors handling the I_ILI class
 dim(I_ILI) <- c(N_age, s_ILI, trans_classes)
 dim(aux_II_ILI) <- c(N_age, s_ILI, trans_classes)
-dim(delta_I_ILI) <- c(N_age, s_ILI, trans_classes)
+dim(new_I_ILI) <- c(N_age, s_ILI, trans_classes)
 dim(n_II_ILI) <- c(N_age, s_ILI, trans_classes)
 dim(p_hosp_ILI) <- N_age
 
 ## Vectors handling the I_comm_D class
 dim(I_comm_D) <- c(N_age, s_comm_D, trans_classes)
 dim(aux_II_comm_D) <- c(N_age, s_comm_D, trans_classes)
-dim(delta_I_comm_D) <- c(N_age, s_comm_D, trans_classes)
+dim(new_I_comm_D) <- c(N_age, s_comm_D, trans_classes)
 dim(n_II_comm_D) <- c(N_age, s_comm_D, trans_classes)
 dim(p_death_comm) <- N_age
 
@@ -792,7 +792,7 @@ update(D_tot) <- new_D_hosp_tot + new_D_comm_tot
 p_specificity <- user()
 N_tot_15_64 <- user()
 
-initial(prob_pos) <- 0
+initial(sero_prob_pos) <- 0
 
 ## Our age groups for serology are fixed: we break them down into the
 ##
@@ -809,7 +809,10 @@ initial(prob_pos) <- 0
 ##
 ## NOTE: the R_pre sum sweeps out the second compartment used to
 ## model the mixture of exponentials.
-update(prob_pos) <- sum(new_R_pos[4:13]) / N_tot_15_64 +
+update(sero_prob_pos) <- sum(new_R_pos[4:13]) / N_tot_15_64 +
   (1 - p_specificity) *
   (1 - (sum(new_R_pre[4:13, ]) +
           sum(new_R_neg[4:13]) + sum(new_R_pos[4:13])) / N_tot_15_64)
+
+initial(pillar2_prob_pos) <- 0
+update(pillar2_prob_pos) <- (sum(new_I_ILI) + sum(new_I_mild)) / sum(N_tot)

--- a/man/carehomes_compare.Rd
+++ b/man/carehomes_compare.Rd
@@ -23,7 +23,9 @@ community settings), \code{deaths} (combined deaths - used by some
 nations - if given then \code{deaths_hosp} and \code{deaths_comm} must be
 \code{NA}), \code{admitted} (hospital admissions), \code{new} (new cases),
 \code{npos_15_64} (number of people seropositive in ages 15-64) and
-\code{ntot_15_64} (number of people tested in ages 15-64).}
+\code{ntot_15_64} (number of people tested in ages 15-64), \code{pillar2_pos}
+(number of pillar 2 positives), \code{pillar2_tot} (number of pillar 2
+tests)}
 
 \item{pars}{A list of parameters, as created by
 \code{\link[=carehomes_parameters]{carehomes_parameters()}}}

--- a/man/carehomes_index.Rd
+++ b/man/carehomes_index.Rd
@@ -15,12 +15,11 @@ A list with element \code{run}, indicating the locations of (in
 order) (1) ICU, (2) general, (3) deaths in community, (4) deaths
 in hospital, (5) total deaths, (6) cumulative confirmed
 admissions,(7) cumulative confirmed new admissions, (8)
-recovered pre seroconversion (15 - 64 year-olds only), (9)
-recovered seronegative and (10) recovered seropositive, and with
-element \code{state} containing the same values followed by 17 S
-compartments (one per age group, then one for carehome workers
-and carehome residents respectively) and 17 "cumulative
-admission" compartments.
+probability of a positive sero test, (9) probability of a positive
+pillar 2 test, and with element \code{state} containing the same values
+followed by 17 S compartments (one per age group, then one for
+carehome workers and carehome residents respectively) and 17
+"cumulative admission" compartments.
 }
 \description{
 Index of "interesting" elements for the carehomes model. This function

--- a/src/carehomes.cpp
+++ b/src/carehomes.cpp
@@ -39,11 +39,6 @@ public:
     real_t comm_D_transmission;
     std::vector<real_t> delta_D_comm;
     std::vector<real_t> delta_D_hosp;
-    std::vector<real_t> delta_E;
-    std::vector<real_t> delta_I_asympt;
-    std::vector<real_t> delta_I_comm_D;
-    std::vector<real_t> delta_I_ILI;
-    std::vector<real_t> delta_I_mild;
     std::vector<real_t> delta_PCR_pos;
     std::vector<real_t> delta_R;
     std::vector<real_t> delta_R_neg;
@@ -148,31 +143,6 @@ public:
     int_t dim_D_hosp;
     int_t dim_delta_D_comm;
     int_t dim_delta_D_hosp;
-    int_t dim_delta_E;
-    int_t dim_delta_E_1;
-    int_t dim_delta_E_12;
-    int_t dim_delta_E_2;
-    int_t dim_delta_E_3;
-    int_t dim_delta_I_asympt;
-    int_t dim_delta_I_asympt_1;
-    int_t dim_delta_I_asympt_12;
-    int_t dim_delta_I_asympt_2;
-    int_t dim_delta_I_asympt_3;
-    int_t dim_delta_I_comm_D;
-    int_t dim_delta_I_comm_D_1;
-    int_t dim_delta_I_comm_D_12;
-    int_t dim_delta_I_comm_D_2;
-    int_t dim_delta_I_comm_D_3;
-    int_t dim_delta_I_ILI;
-    int_t dim_delta_I_ILI_1;
-    int_t dim_delta_I_ILI_12;
-    int_t dim_delta_I_ILI_2;
-    int_t dim_delta_I_ILI_3;
-    int_t dim_delta_I_mild;
-    int_t dim_delta_I_mild_1;
-    int_t dim_delta_I_mild_12;
-    int_t dim_delta_I_mild_2;
-    int_t dim_delta_I_mild_3;
     int_t dim_delta_PCR_pos;
     int_t dim_delta_PCR_pos_1;
     int_t dim_delta_PCR_pos_2;
@@ -457,6 +427,21 @@ public:
     int_t dim_N_tot;
     int_t dim_new_D_comm;
     int_t dim_new_D_hosp;
+    int_t dim_new_E;
+    int_t dim_new_E_1;
+    int_t dim_new_E_12;
+    int_t dim_new_E_2;
+    int_t dim_new_E_3;
+    int_t dim_new_I_asympt;
+    int_t dim_new_I_asympt_1;
+    int_t dim_new_I_asympt_12;
+    int_t dim_new_I_asympt_2;
+    int_t dim_new_I_asympt_3;
+    int_t dim_new_I_comm_D;
+    int_t dim_new_I_comm_D_1;
+    int_t dim_new_I_comm_D_12;
+    int_t dim_new_I_comm_D_2;
+    int_t dim_new_I_comm_D_3;
     int_t dim_new_I_hosp_D_conf;
     int_t dim_new_I_hosp_D_conf_1;
     int_t dim_new_I_hosp_D_conf_12;
@@ -497,6 +482,16 @@ public:
     int_t dim_new_I_ICU_R_unconf_12;
     int_t dim_new_I_ICU_R_unconf_2;
     int_t dim_new_I_ICU_R_unconf_3;
+    int_t dim_new_I_ILI;
+    int_t dim_new_I_ILI_1;
+    int_t dim_new_I_ILI_12;
+    int_t dim_new_I_ILI_2;
+    int_t dim_new_I_ILI_3;
+    int_t dim_new_I_mild;
+    int_t dim_new_I_mild_1;
+    int_t dim_new_I_mild_12;
+    int_t dim_new_I_mild_2;
+    int_t dim_new_I_mild_3;
     int_t dim_new_I_triage_D_conf;
     int_t dim_new_I_triage_D_conf_1;
     int_t dim_new_I_triage_D_conf_12;
@@ -619,7 +614,7 @@ public:
     std::vector<real_t> initial_N_tot;
     real_t initial_N_tot2;
     std::vector<real_t> initial_PCR_pos;
-    real_t initial_prob_pos;
+    real_t initial_pillar2_prob_pos;
     std::vector<real_t> initial_R;
     std::vector<real_t> initial_R_neg;
     std::vector<real_t> initial_R_pos;
@@ -627,6 +622,7 @@ public:
     std::vector<real_t> initial_R_stepdown_conf;
     std::vector<real_t> initial_R_stepdown_unconf;
     std::vector<real_t> initial_S;
+    real_t initial_sero_prob_pos;
     real_t initial_time;
     std::vector<real_t> lambda;
     std::vector<real_t> m;
@@ -680,6 +676,9 @@ public:
     real_t N_tot_15_64;
     std::vector<real_t> new_D_comm;
     std::vector<real_t> new_D_hosp;
+    std::vector<real_t> new_E;
+    std::vector<real_t> new_I_asympt;
+    std::vector<real_t> new_I_comm_D;
     std::vector<real_t> new_I_hosp_D_conf;
     std::vector<real_t> new_I_hosp_D_unconf;
     std::vector<real_t> new_I_hosp_R_conf;
@@ -688,6 +687,8 @@ public:
     std::vector<real_t> new_I_ICU_D_unconf;
     std::vector<real_t> new_I_ICU_R_conf;
     std::vector<real_t> new_I_ICU_R_unconf;
+    std::vector<real_t> new_I_ILI;
+    std::vector<real_t> new_I_mild;
     std::vector<real_t> new_I_triage_D_conf;
     std::vector<real_t> new_I_triage_D_unconf;
     std::vector<real_t> new_I_triage_R_conf;
@@ -771,10 +772,10 @@ public:
   carehomes(const init_t& data): internal(data) {
   }
   size_t size() {
-    return 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf + internal.dim_I_ICU_D_unconf + internal.dim_I_ICU_D_conf;
+    return 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf + internal.dim_I_ICU_D_unconf + internal.dim_I_ICU_D_conf;
   }
   std::vector<real_t> initial(size_t step) {
-    std::vector<real_t> state(13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf + internal.dim_I_ICU_D_unconf + internal.dim_I_ICU_D_conf);
+    std::vector<real_t> state(14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf + internal.dim_I_ICU_D_unconf + internal.dim_I_ICU_D_conf);
     state[0] = internal.initial_time;
     state[1] = internal.initial_cum_infections;
     state[2] = internal.initial_cum_admit_conf;
@@ -787,8 +788,9 @@ public:
     state[9] = internal.initial_D_hosp_tot;
     state[10] = internal.initial_D_comm_tot;
     state[11] = internal.initial_D_tot;
-    state[12] = internal.initial_prob_pos;
-    std::copy(internal.initial_S.begin(), internal.initial_S.end(), state.begin() + 13);
+    state[12] = internal.initial_sero_prob_pos;
+    state[13] = internal.initial_pillar2_prob_pos;
+    std::copy(internal.initial_S.begin(), internal.initial_S.end(), state.begin() + 14);
     std::copy(internal.initial_R_pos.begin(), internal.initial_R_pos.end(), state.begin() + internal.offset_variable_R_pos);
     std::copy(internal.initial_R_neg.begin(), internal.initial_R_neg.end(), state.begin() + internal.offset_variable_R_neg);
     std::copy(internal.initial_R.begin(), internal.initial_R.end(), state.begin() + internal.offset_variable_R);
@@ -823,7 +825,7 @@ public:
   __device__
   #endif
   void update(size_t step, const real_t * state, dust::rng_state_t<real_t>& rng_state, real_t * state_next) {
-    const real_t * S = state + 13;
+    const real_t * S = state + 14;
     const real_t * E = state + internal.offset_variable_E;
     const real_t * I_asympt = state + internal.offset_variable_I_asympt;
     const real_t * I_mild = state + internal.offset_variable_I_mild;
@@ -854,6 +856,7 @@ public:
     const real_t cum_new_conf = state[3];
     const real_t * cum_admit_by_age = state + internal.offset_variable_cum_admit_by_age;
     const real_t cum_infections = state[1];
+    const real_t * N_tot = state + internal.offset_variable_N_tot;
     state_next[5] = odin_sum1(S, 0, internal.dim_S) + odin_sum1(R_pre, 0, internal.dim_R_pre) + odin_sum1(R_pos, 0, internal.dim_R_pos) + odin_sum1(R_neg, 0, internal.dim_R_neg) + odin_sum1(E, 0, internal.dim_E);
     state_next[0] = (step + 1) * internal.dt;
     real_t beta = (step >= internal.dim_beta_step ? internal.beta_step[internal.dim_beta_step - 1] : internal.beta_step[step + 1 - 1]);
@@ -1482,13 +1485,6 @@ public:
         }
       }
     }
-    for (int_t i = 1; i <= internal.dim_delta_I_asympt_1; ++i) {
-      for (int_t j = 1; j <= internal.dim_delta_I_asympt_2; ++j) {
-        for (int_t k = 1; k <= internal.dim_delta_I_asympt_3; ++k) {
-          internal.delta_I_asympt[i - 1 + internal.dim_delta_I_asympt_1 * (j - 1) + internal.dim_delta_I_asympt_12 * (k - 1)] = internal.aux_II_asympt[internal.dim_aux_II_asympt_12 * (k - 1) + internal.dim_aux_II_asympt_1 * (j - 1) + i - 1];
-        }
-      }
-    }
     for (int_t i = 1; i <= internal.dim_delta_R_neg; ++i) {
       internal.delta_R_neg[i - 1] = odin_sum2(internal.n_R_pre.data(), i - 1, i, 0, internal.dim_n_R_pre_2, internal.dim_n_R_pre_1) - internal.delta_R_pos[i - 1];
     }
@@ -1507,6 +1503,13 @@ public:
     }
     real_t new_D_comm_tot = odin_sum1(internal.new_D_comm.data(), 0, internal.dim_new_D_comm);
     real_t new_D_hosp_tot = odin_sum1(internal.new_D_hosp.data(), 0, internal.dim_new_D_hosp);
+    for (int_t i = 1; i <= internal.dim_new_I_asympt_1; ++i) {
+      for (int_t j = 1; j <= internal.dim_new_I_asympt_2; ++j) {
+        for (int_t k = 1; k <= internal.dim_new_I_asympt_3; ++k) {
+          internal.new_I_asympt[i - 1 + internal.dim_new_I_asympt_1 * (j - 1) + internal.dim_new_I_asympt_12 * (k - 1)] = I_asympt[internal.dim_I_asympt_12 * (k - 1) + internal.dim_I_asympt_1 * (j - 1) + i - 1] + internal.aux_II_asympt[internal.dim_aux_II_asympt_12 * (k - 1) + internal.dim_aux_II_asympt_1 * (j - 1) + i - 1];
+        }
+      }
+    }
     for (int_t i = 1; i <= internal.dim_new_I_ICU_D_conf_1; ++i) {
       for (int_t j = 1; j <= internal.dim_new_I_ICU_D_conf_2; ++j) {
         for (int_t k = 1; k <= internal.dim_new_I_ICU_D_conf_3; ++k) {
@@ -1583,26 +1586,26 @@ public:
         }
       }
     }
-    for (int_t i = 1; i <= internal.dim_delta_I_comm_D_1; ++i) {
-      for (int_t j = 1; j <= internal.dim_delta_I_comm_D_2; ++j) {
-        for (int_t k = 1; k <= internal.dim_delta_I_comm_D_3; ++k) {
-          internal.delta_I_comm_D[i - 1 + internal.dim_delta_I_comm_D_1 * (j - 1) + internal.dim_delta_I_comm_D_12 * (k - 1)] = internal.aux_II_comm_D[internal.dim_aux_II_comm_D_12 * (k - 1) + internal.dim_aux_II_comm_D_1 * (j - 1) + i - 1];
-        }
-      }
-    }
-    for (int_t i = 1; i <= internal.dim_delta_I_mild_1; ++i) {
-      for (int_t j = 1; j <= internal.dim_delta_I_mild_2; ++j) {
-        for (int_t k = 1; k <= internal.dim_delta_I_mild_3; ++k) {
-          internal.delta_I_mild[i - 1 + internal.dim_delta_I_mild_1 * (j - 1) + internal.dim_delta_I_mild_12 * (k - 1)] = internal.aux_II_mild[internal.dim_aux_II_mild_12 * (k - 1) + internal.dim_aux_II_mild_1 * (j - 1) + i - 1];
-        }
-      }
-    }
     for (int_t i = 1; i <= internal.dim_n_ILI_to_triage_1; ++i) {
       for (int_t j = 1; j <= internal.dim_n_ILI_to_triage_2; ++j) {
         internal.n_ILI_to_triage[i - 1 + internal.dim_n_ILI_to_triage_1 * (j - 1)] = dust::distr::rbinom(rng_state, std::round(internal.n_ILI_to_hosp[internal.dim_n_ILI_to_hosp_1 * (j - 1) + i - 1]), internal.p_ICU_hosp[i - 1]);
       }
     }
+    for (int_t i = 1; i <= internal.dim_new_I_comm_D_1; ++i) {
+      for (int_t j = 1; j <= internal.dim_new_I_comm_D_2; ++j) {
+        for (int_t k = 1; k <= internal.dim_new_I_comm_D_3; ++k) {
+          internal.new_I_comm_D[i - 1 + internal.dim_new_I_comm_D_1 * (j - 1) + internal.dim_new_I_comm_D_12 * (k - 1)] = I_comm_D[internal.dim_I_comm_D_12 * (k - 1) + internal.dim_I_comm_D_1 * (j - 1) + i - 1] + internal.aux_II_comm_D[internal.dim_aux_II_comm_D_12 * (k - 1) + internal.dim_aux_II_comm_D_1 * (j - 1) + i - 1];
+        }
+      }
+    }
     real_t new_I_ICU_tot = odin_sum1(internal.new_I_ICU_R_conf.data(), 0, internal.dim_new_I_ICU_R_conf) + odin_sum1(internal.new_I_ICU_D_conf.data(), 0, internal.dim_new_I_ICU_D_conf);
+    for (int_t i = 1; i <= internal.dim_new_I_mild_1; ++i) {
+      for (int_t j = 1; j <= internal.dim_new_I_mild_2; ++j) {
+        for (int_t k = 1; k <= internal.dim_new_I_mild_3; ++k) {
+          internal.new_I_mild[i - 1 + internal.dim_new_I_mild_1 * (j - 1) + internal.dim_new_I_mild_12 * (k - 1)] = I_mild[internal.dim_I_mild_12 * (k - 1) + internal.dim_I_mild_1 * (j - 1) + i - 1] + internal.aux_II_mild[internal.dim_aux_II_mild_12 * (k - 1) + internal.dim_aux_II_mild_1 * (j - 1) + i - 1];
+        }
+      }
+    }
     for (int_t i = 1; i <= internal.dim_new_R_neg; ++i) {
       internal.new_R_neg[i - 1] = R_neg[i - 1] + internal.delta_R_neg[i - 1];
     }
@@ -1618,7 +1621,7 @@ public:
     for (int_t i = 1; i <= internal.dim_I_asympt_1; ++i) {
       for (int_t j = 1; j <= internal.dim_I_asympt_2; ++j) {
         for (int_t k = 1; k <= internal.dim_I_asympt_3; ++k) {
-          state_next[internal.offset_variable_I_asympt + i - 1 + internal.dim_I_asympt_1 * (j - 1) + internal.dim_I_asympt_12 * (k - 1)] = I_asympt[internal.dim_I_asympt_12 * (k - 1) + internal.dim_I_asympt_1 * (j - 1) + i - 1] + internal.delta_I_asympt[internal.dim_delta_I_asympt_12 * (k - 1) + internal.dim_delta_I_asympt_1 * (j - 1) + i - 1];
+          state_next[internal.offset_variable_I_asympt + i - 1 + internal.dim_I_asympt_1 * (j - 1) + internal.dim_I_asympt_12 * (k - 1)] = internal.new_I_asympt[internal.dim_new_I_asympt_12 * (k - 1) + internal.dim_new_I_asympt_1 * (j - 1) + i - 1];
         }
       }
     }
@@ -1663,13 +1666,6 @@ public:
         state_next[internal.offset_variable_R_stepdown_unconf + i - 1 + internal.dim_R_stepdown_unconf_1 * (j - 1)] = internal.new_R_stepdown_unconf[internal.dim_new_R_stepdown_unconf_1 * (j - 1) + i - 1];
       }
     }
-    for (int_t i = 1; i <= internal.dim_delta_I_ILI_1; ++i) {
-      for (int_t j = 1; j <= internal.dim_delta_I_ILI_2; ++j) {
-        for (int_t k = 1; k <= internal.dim_delta_I_ILI_3; ++k) {
-          internal.delta_I_ILI[i - 1 + internal.dim_delta_I_ILI_1 * (j - 1) + internal.dim_delta_I_ILI_12 * (k - 1)] = internal.aux_II_ILI[internal.dim_aux_II_ILI_12 * (k - 1) + internal.dim_aux_II_ILI_1 * (j - 1) + i - 1];
-        }
-      }
-    }
     for (int_t i = 1; i <= internal.dim_n_hosp_non_ICU_1; ++i) {
       for (int_t j = 1; j <= internal.dim_n_hosp_non_ICU_2; ++j) {
         internal.n_hosp_non_ICU[i - 1 + internal.dim_n_hosp_non_ICU_1 * (j - 1)] = internal.n_ILI_to_hosp[internal.dim_n_ILI_to_hosp_1 * (j - 1) + i - 1] - internal.n_ILI_to_triage[internal.dim_n_ILI_to_triage_1 * (j - 1) + i - 1];
@@ -1683,10 +1679,17 @@ public:
     for (int_t i = 1; i <= internal.dim_n_SE; ++i) {
       internal.n_SE[i - 1] = dust::distr::rbinom(rng_state, std::round(S[i - 1]), internal.p_SE[i - 1]);
     }
+    for (int_t i = 1; i <= internal.dim_new_I_ILI_1; ++i) {
+      for (int_t j = 1; j <= internal.dim_new_I_ILI_2; ++j) {
+        for (int_t k = 1; k <= internal.dim_new_I_ILI_3; ++k) {
+          internal.new_I_ILI[i - 1 + internal.dim_new_I_ILI_1 * (j - 1) + internal.dim_new_I_ILI_12 * (k - 1)] = I_ILI[internal.dim_I_ILI_12 * (k - 1) + internal.dim_I_ILI_1 * (j - 1) + i - 1] + internal.aux_II_ILI[internal.dim_aux_II_ILI_12 * (k - 1) + internal.dim_aux_II_ILI_1 * (j - 1) + i - 1];
+        }
+      }
+    }
     for (int_t i = 1; i <= internal.dim_I_comm_D_1; ++i) {
       for (int_t j = 1; j <= internal.dim_I_comm_D_2; ++j) {
         for (int_t k = 1; k <= internal.dim_I_comm_D_3; ++k) {
-          state_next[internal.offset_variable_I_comm_D + i - 1 + internal.dim_I_comm_D_1 * (j - 1) + internal.dim_I_comm_D_12 * (k - 1)] = I_comm_D[internal.dim_I_comm_D_12 * (k - 1) + internal.dim_I_comm_D_1 * (j - 1) + i - 1] + internal.delta_I_comm_D[internal.dim_delta_I_comm_D_12 * (k - 1) + internal.dim_delta_I_comm_D_1 * (j - 1) + i - 1];
+          state_next[internal.offset_variable_I_comm_D + i - 1 + internal.dim_I_comm_D_1 * (j - 1) + internal.dim_I_comm_D_12 * (k - 1)] = internal.new_I_comm_D[internal.dim_new_I_comm_D_12 * (k - 1) + internal.dim_new_I_comm_D_1 * (j - 1) + i - 1];
         }
       }
     }
@@ -1694,14 +1697,14 @@ public:
     for (int_t i = 1; i <= internal.dim_I_mild_1; ++i) {
       for (int_t j = 1; j <= internal.dim_I_mild_2; ++j) {
         for (int_t k = 1; k <= internal.dim_I_mild_3; ++k) {
-          state_next[internal.offset_variable_I_mild + i - 1 + internal.dim_I_mild_1 * (j - 1) + internal.dim_I_mild_12 * (k - 1)] = I_mild[internal.dim_I_mild_12 * (k - 1) + internal.dim_I_mild_1 * (j - 1) + i - 1] + internal.delta_I_mild[internal.dim_delta_I_mild_12 * (k - 1) + internal.dim_delta_I_mild_1 * (j - 1) + i - 1];
+          state_next[internal.offset_variable_I_mild + i - 1 + internal.dim_I_mild_1 * (j - 1) + internal.dim_I_mild_12 * (k - 1)] = internal.new_I_mild[internal.dim_new_I_mild_12 * (k - 1) + internal.dim_new_I_mild_1 * (j - 1) + i - 1];
         }
       }
     }
-    state_next[12] = odin_sum1(internal.new_R_pos.data(), 3, 13) / (real_t) internal.N_tot_15_64 + (1 - internal.p_specificity) * (1 - (odin_sum2(internal.new_R_pre.data(), 3, 13, 0, internal.dim_new_R_pre_2, internal.dim_new_R_pre_1) + odin_sum1(internal.new_R_neg.data(), 3, 13) + odin_sum1(internal.new_R_pos.data(), 3, 13)) / (real_t) internal.N_tot_15_64);
     for (int_t i = 1; i <= internal.dim_R_neg; ++i) {
       state_next[internal.offset_variable_R_neg + i - 1] = internal.new_R_neg[i - 1];
     }
+    state_next[12] = odin_sum1(internal.new_R_pos.data(), 3, 13) / (real_t) internal.N_tot_15_64 + (1 - internal.p_specificity) * (1 - (odin_sum2(internal.new_R_pre.data(), 3, 13, 0, internal.dim_new_R_pre_2, internal.dim_new_R_pre_1) + odin_sum1(internal.new_R_neg.data(), 3, 13) + odin_sum1(internal.new_R_pos.data(), 3, 13)) / (real_t) internal.N_tot_15_64);
     for (int_t i = 1; i <= internal.dim_aux_EE_1; ++i) {
       int_t j = 1;
       int_t k = 1;
@@ -1765,19 +1768,13 @@ public:
     for (int_t i = 1; i <= internal.dim_I_ILI_1; ++i) {
       for (int_t j = 1; j <= internal.dim_I_ILI_2; ++j) {
         for (int_t k = 1; k <= internal.dim_I_ILI_3; ++k) {
-          state_next[internal.offset_variable_I_ILI + i - 1 + internal.dim_I_ILI_1 * (j - 1) + internal.dim_I_ILI_12 * (k - 1)] = I_ILI[internal.dim_I_ILI_12 * (k - 1) + internal.dim_I_ILI_1 * (j - 1) + i - 1] + internal.delta_I_ILI[internal.dim_delta_I_ILI_12 * (k - 1) + internal.dim_delta_I_ILI_1 * (j - 1) + i - 1];
+          state_next[internal.offset_variable_I_ILI + i - 1 + internal.dim_I_ILI_1 * (j - 1) + internal.dim_I_ILI_12 * (k - 1)] = internal.new_I_ILI[internal.dim_new_I_ILI_12 * (k - 1) + internal.dim_new_I_ILI_1 * (j - 1) + i - 1];
         }
       }
     }
+    state_next[13] = (odin_sum1(internal.new_I_ILI.data(), 0, internal.dim_new_I_ILI) + odin_sum1(internal.new_I_mild.data(), 0, internal.dim_new_I_mild)) / (real_t) odin_sum1(N_tot, 0, internal.dim_N_tot);
     for (int_t i = 1; i <= internal.dim_S; ++i) {
-      state_next[13 + i - 1] = S[i - 1] - internal.n_SE[i - 1];
-    }
-    for (int_t i = 1; i <= internal.dim_delta_E_1; ++i) {
-      for (int_t j = 1; j <= internal.dim_delta_E_2; ++j) {
-        for (int_t k = 1; k <= internal.dim_delta_E_3; ++k) {
-          internal.delta_E[i - 1 + internal.dim_delta_E_1 * (j - 1) + internal.dim_delta_E_12 * (k - 1)] = internal.aux_EE[internal.dim_aux_EE_12 * (k - 1) + internal.dim_aux_EE_1 * (j - 1) + i - 1];
-        }
-      }
+      state_next[14 + i - 1] = S[i - 1] - internal.n_SE[i - 1];
     }
     for (int_t i = 1; i <= internal.dim_n_ILI_to_hosp_D_conf_1; ++i) {
       for (int_t j = 1; j <= internal.dim_n_ILI_to_hosp_D_conf_2; ++j) {
@@ -1792,6 +1789,13 @@ public:
     for (int_t i = 1; i <= internal.dim_n_ILI_to_triage_R_conf_1; ++i) {
       for (int_t j = 1; j <= internal.dim_n_ILI_to_triage_R_conf_2; ++j) {
         internal.n_ILI_to_triage_R_conf[i - 1 + internal.dim_n_ILI_to_triage_R_conf_1 * (j - 1)] = dust::distr::rbinom(rng_state, std::round(internal.n_ILI_to_triage_R[internal.dim_n_ILI_to_triage_R_1 * (j - 1) + i - 1]), internal.p_admit_conf[i - 1]);
+      }
+    }
+    for (int_t i = 1; i <= internal.dim_new_E_1; ++i) {
+      for (int_t j = 1; j <= internal.dim_new_E_2; ++j) {
+        for (int_t k = 1; k <= internal.dim_new_E_3; ++k) {
+          internal.new_E[i - 1 + internal.dim_new_E_1 * (j - 1) + internal.dim_new_E_12 * (k - 1)] = E[internal.dim_E_12 * (k - 1) + internal.dim_E_1 * (j - 1) + i - 1] + internal.aux_EE[internal.dim_aux_EE_12 * (k - 1) + internal.dim_aux_EE_1 * (j - 1) + i - 1];
+        }
       }
     }
     for (int_t i = 1; i <= internal.dim_new_I_triage_D_conf_1; ++i) {
@@ -1885,7 +1889,7 @@ public:
     for (int_t i = 1; i <= internal.dim_E_1; ++i) {
       for (int_t j = 1; j <= internal.dim_E_2; ++j) {
         for (int_t k = 1; k <= internal.dim_E_3; ++k) {
-          state_next[internal.offset_variable_E + i - 1 + internal.dim_E_1 * (j - 1) + internal.dim_E_12 * (k - 1)] = E[internal.dim_E_12 * (k - 1) + internal.dim_E_1 * (j - 1) + i - 1] + internal.delta_E[internal.dim_delta_E_12 * (k - 1) + internal.dim_delta_E_1 * (j - 1) + i - 1];
+          state_next[internal.offset_variable_E + i - 1 + internal.dim_E_1 * (j - 1) + internal.dim_E_12 * (k - 1)] = internal.new_E[internal.dim_new_E_12 * (k - 1) + internal.dim_new_E_1 * (j - 1) + i - 1];
         }
       }
     }
@@ -2251,7 +2255,8 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.initial_hosp_tot = 0;
   internal.initial_I_ICU_tot = 0;
   internal.initial_N_tot2 = 0;
-  internal.initial_prob_pos = 0;
+  internal.initial_pillar2_prob_pos = 0;
+  internal.initial_sero_prob_pos = 0;
   internal.initial_time = 0;
   internal.gamma_R_pre = std::vector<real_t>(internal.dim_gamma_R_pre);
   internal.comm_D_transmission = NA_REAL;
@@ -2391,21 +2396,6 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.dim_D_hosp = internal.N_age;
   internal.dim_delta_D_comm = internal.N_age;
   internal.dim_delta_D_hosp = internal.N_age;
-  internal.dim_delta_E_1 = internal.N_age;
-  internal.dim_delta_E_2 = internal.s_E;
-  internal.dim_delta_E_3 = internal.trans_classes;
-  internal.dim_delta_I_asympt_1 = internal.N_age;
-  internal.dim_delta_I_asympt_2 = internal.s_asympt;
-  internal.dim_delta_I_asympt_3 = internal.trans_classes;
-  internal.dim_delta_I_comm_D_1 = internal.N_age;
-  internal.dim_delta_I_comm_D_2 = internal.s_comm_D;
-  internal.dim_delta_I_comm_D_3 = internal.trans_classes;
-  internal.dim_delta_I_ILI_1 = internal.N_age;
-  internal.dim_delta_I_ILI_2 = internal.s_ILI;
-  internal.dim_delta_I_ILI_3 = internal.trans_classes;
-  internal.dim_delta_I_mild_1 = internal.N_age;
-  internal.dim_delta_I_mild_2 = internal.s_mild;
-  internal.dim_delta_I_mild_3 = internal.trans_classes;
   internal.dim_delta_PCR_pos_1 = internal.N_age;
   internal.dim_delta_PCR_pos_2 = internal.s_PCR_pos;
   internal.dim_delta_R = internal.N_age;
@@ -2584,6 +2574,15 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.dim_N_tot = internal.N_age;
   internal.dim_new_D_comm = internal.N_age;
   internal.dim_new_D_hosp = internal.N_age;
+  internal.dim_new_E_1 = internal.N_age;
+  internal.dim_new_E_2 = internal.s_E;
+  internal.dim_new_E_3 = internal.trans_classes;
+  internal.dim_new_I_asympt_1 = internal.N_age;
+  internal.dim_new_I_asympt_2 = internal.s_asympt;
+  internal.dim_new_I_asympt_3 = internal.trans_classes;
+  internal.dim_new_I_comm_D_1 = internal.N_age;
+  internal.dim_new_I_comm_D_2 = internal.s_comm_D;
+  internal.dim_new_I_comm_D_3 = internal.trans_classes;
   internal.dim_new_I_hosp_D_conf_1 = internal.N_age;
   internal.dim_new_I_hosp_D_conf_2 = internal.s_hosp_D;
   internal.dim_new_I_hosp_D_conf_3 = internal.trans_classes;
@@ -2608,6 +2607,12 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.dim_new_I_ICU_R_unconf_1 = internal.N_age;
   internal.dim_new_I_ICU_R_unconf_2 = internal.s_ICU_R;
   internal.dim_new_I_ICU_R_unconf_3 = internal.trans_classes;
+  internal.dim_new_I_ILI_1 = internal.N_age;
+  internal.dim_new_I_ILI_2 = internal.s_ILI;
+  internal.dim_new_I_ILI_3 = internal.trans_classes;
+  internal.dim_new_I_mild_1 = internal.N_age;
+  internal.dim_new_I_mild_2 = internal.s_mild;
+  internal.dim_new_I_mild_3 = internal.trans_classes;
   internal.dim_new_I_triage_D_conf_1 = internal.N_age;
   internal.dim_new_I_triage_D_conf_2 = internal.s_triage;
   internal.dim_new_I_triage_D_conf_3 = internal.trans_classes;
@@ -2729,16 +2734,6 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.dim_aux_p_bin = internal.dim_aux_p_bin_1 * internal.dim_aux_p_bin_2;
   internal.dim_aux_R_stepdown_conf = internal.dim_aux_R_stepdown_conf_1 * internal.dim_aux_R_stepdown_conf_2;
   internal.dim_aux_R_stepdown_unconf = internal.dim_aux_R_stepdown_unconf_1 * internal.dim_aux_R_stepdown_unconf_2;
-  internal.dim_delta_E = internal.dim_delta_E_1 * internal.dim_delta_E_2 * internal.dim_delta_E_3;
-  internal.dim_delta_E_12 = internal.dim_delta_E_1 * internal.dim_delta_E_2;
-  internal.dim_delta_I_asympt = internal.dim_delta_I_asympt_1 * internal.dim_delta_I_asympt_2 * internal.dim_delta_I_asympt_3;
-  internal.dim_delta_I_asympt_12 = internal.dim_delta_I_asympt_1 * internal.dim_delta_I_asympt_2;
-  internal.dim_delta_I_comm_D = internal.dim_delta_I_comm_D_1 * internal.dim_delta_I_comm_D_2 * internal.dim_delta_I_comm_D_3;
-  internal.dim_delta_I_comm_D_12 = internal.dim_delta_I_comm_D_1 * internal.dim_delta_I_comm_D_2;
-  internal.dim_delta_I_ILI = internal.dim_delta_I_ILI_1 * internal.dim_delta_I_ILI_2 * internal.dim_delta_I_ILI_3;
-  internal.dim_delta_I_ILI_12 = internal.dim_delta_I_ILI_1 * internal.dim_delta_I_ILI_2;
-  internal.dim_delta_I_mild = internal.dim_delta_I_mild_1 * internal.dim_delta_I_mild_2 * internal.dim_delta_I_mild_3;
-  internal.dim_delta_I_mild_12 = internal.dim_delta_I_mild_1 * internal.dim_delta_I_mild_2;
   internal.dim_delta_PCR_pos = internal.dim_delta_PCR_pos_1 * internal.dim_delta_PCR_pos_2;
   internal.dim_E = internal.dim_E_1 * internal.dim_E_2 * internal.dim_E_3;
   internal.dim_E_12 = internal.dim_E_1 * internal.dim_E_2;
@@ -2844,6 +2839,12 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.dim_n_R_stepdown_conf = internal.dim_n_R_stepdown_conf_1 * internal.dim_n_R_stepdown_conf_2;
   internal.dim_n_R_stepdown_unconf = internal.dim_n_R_stepdown_unconf_1 * internal.dim_n_R_stepdown_unconf_2;
   internal.dim_n_R_stepdown_unconf_to_conf = internal.dim_n_R_stepdown_unconf_to_conf_1 * internal.dim_n_R_stepdown_unconf_to_conf_2;
+  internal.dim_new_E = internal.dim_new_E_1 * internal.dim_new_E_2 * internal.dim_new_E_3;
+  internal.dim_new_E_12 = internal.dim_new_E_1 * internal.dim_new_E_2;
+  internal.dim_new_I_asympt = internal.dim_new_I_asympt_1 * internal.dim_new_I_asympt_2 * internal.dim_new_I_asympt_3;
+  internal.dim_new_I_asympt_12 = internal.dim_new_I_asympt_1 * internal.dim_new_I_asympt_2;
+  internal.dim_new_I_comm_D = internal.dim_new_I_comm_D_1 * internal.dim_new_I_comm_D_2 * internal.dim_new_I_comm_D_3;
+  internal.dim_new_I_comm_D_12 = internal.dim_new_I_comm_D_1 * internal.dim_new_I_comm_D_2;
   internal.dim_new_I_hosp_D_conf = internal.dim_new_I_hosp_D_conf_1 * internal.dim_new_I_hosp_D_conf_2 * internal.dim_new_I_hosp_D_conf_3;
   internal.dim_new_I_hosp_D_conf_12 = internal.dim_new_I_hosp_D_conf_1 * internal.dim_new_I_hosp_D_conf_2;
   internal.dim_new_I_hosp_D_unconf = internal.dim_new_I_hosp_D_unconf_1 * internal.dim_new_I_hosp_D_unconf_2 * internal.dim_new_I_hosp_D_unconf_3;
@@ -2860,6 +2861,10 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.dim_new_I_ICU_R_conf_12 = internal.dim_new_I_ICU_R_conf_1 * internal.dim_new_I_ICU_R_conf_2;
   internal.dim_new_I_ICU_R_unconf = internal.dim_new_I_ICU_R_unconf_1 * internal.dim_new_I_ICU_R_unconf_2 * internal.dim_new_I_ICU_R_unconf_3;
   internal.dim_new_I_ICU_R_unconf_12 = internal.dim_new_I_ICU_R_unconf_1 * internal.dim_new_I_ICU_R_unconf_2;
+  internal.dim_new_I_ILI = internal.dim_new_I_ILI_1 * internal.dim_new_I_ILI_2 * internal.dim_new_I_ILI_3;
+  internal.dim_new_I_ILI_12 = internal.dim_new_I_ILI_1 * internal.dim_new_I_ILI_2;
+  internal.dim_new_I_mild = internal.dim_new_I_mild_1 * internal.dim_new_I_mild_2 * internal.dim_new_I_mild_3;
+  internal.dim_new_I_mild_12 = internal.dim_new_I_mild_1 * internal.dim_new_I_mild_2;
   internal.dim_new_I_triage_D_conf = internal.dim_new_I_triage_D_conf_1 * internal.dim_new_I_triage_D_conf_2 * internal.dim_new_I_triage_D_conf_3;
   internal.dim_new_I_triage_D_conf_12 = internal.dim_new_I_triage_D_conf_1 * internal.dim_new_I_triage_D_conf_2;
   internal.dim_new_I_triage_D_unconf = internal.dim_new_I_triage_D_unconf_1 * internal.dim_new_I_triage_D_unconf_2 * internal.dim_new_I_triage_D_unconf_3;
@@ -2911,14 +2916,14 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   for (int_t i = 1; i <= internal.dim_S; ++i) {
     internal.initial_S[i - 1] = 0;
   }
-  internal.offset_variable_cum_admit_by_age = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm;
-  internal.offset_variable_D_comm = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp;
-  internal.offset_variable_D_hosp = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R;
-  internal.offset_variable_N_tot = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age;
-  internal.offset_variable_R = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg;
-  internal.offset_variable_R_neg = 13 + internal.dim_S + internal.dim_R_pos;
-  internal.offset_variable_R_pos = 13 + internal.dim_S;
-  internal.offset_variable_R_stepdown_unconf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot;
+  internal.offset_variable_cum_admit_by_age = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm;
+  internal.offset_variable_D_comm = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp;
+  internal.offset_variable_D_hosp = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R;
+  internal.offset_variable_N_tot = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age;
+  internal.offset_variable_R = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg;
+  internal.offset_variable_R_neg = 14 + internal.dim_S + internal.dim_R_pos;
+  internal.offset_variable_R_pos = 14 + internal.dim_S;
+  internal.offset_variable_R_stepdown_unconf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot;
   internal.p_admit_conf = user_get_array_fixed<real_t, 1>(user, "p_admit_conf", internal.p_admit_conf, {internal.dim_p_admit_conf}, NA_REAL, NA_REAL);
   internal.p_asympt = user_get_array_fixed<real_t, 1>(user, "p_asympt", internal.p_asympt, {internal.dim_p_asympt}, NA_REAL, NA_REAL);
   internal.p_death_comm = user_get_array_fixed<real_t, 1>(user, "p_death_comm", internal.p_death_comm, {internal.dim_p_death_comm}, NA_REAL, NA_REAL);
@@ -2948,11 +2953,6 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.aux_p_bin = std::vector<real_t>(internal.dim_aux_p_bin);
   internal.aux_R_stepdown_conf = std::vector<real_t>(internal.dim_aux_R_stepdown_conf);
   internal.aux_R_stepdown_unconf = std::vector<real_t>(internal.dim_aux_R_stepdown_unconf);
-  internal.delta_E = std::vector<real_t>(internal.dim_delta_E);
-  internal.delta_I_asympt = std::vector<real_t>(internal.dim_delta_I_asympt);
-  internal.delta_I_comm_D = std::vector<real_t>(internal.dim_delta_I_comm_D);
-  internal.delta_I_ILI = std::vector<real_t>(internal.dim_delta_I_ILI);
-  internal.delta_I_mild = std::vector<real_t>(internal.dim_delta_I_mild);
   internal.delta_PCR_pos = std::vector<real_t>(internal.dim_delta_PCR_pos);
   internal.I_with_diff_trans = std::vector<real_t>(internal.dim_I_with_diff_trans);
   internal.initial_E = std::vector<real_t>(internal.dim_E);
@@ -3021,6 +3021,9 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.n_R_stepdown_conf = std::vector<real_t>(internal.dim_n_R_stepdown_conf);
   internal.n_R_stepdown_unconf = std::vector<real_t>(internal.dim_n_R_stepdown_unconf);
   internal.n_R_stepdown_unconf_to_conf = std::vector<real_t>(internal.dim_n_R_stepdown_unconf_to_conf);
+  internal.new_E = std::vector<real_t>(internal.dim_new_E);
+  internal.new_I_asympt = std::vector<real_t>(internal.dim_new_I_asympt);
+  internal.new_I_comm_D = std::vector<real_t>(internal.dim_new_I_comm_D);
   internal.new_I_hosp_D_conf = std::vector<real_t>(internal.dim_new_I_hosp_D_conf);
   internal.new_I_hosp_D_unconf = std::vector<real_t>(internal.dim_new_I_hosp_D_unconf);
   internal.new_I_hosp_R_conf = std::vector<real_t>(internal.dim_new_I_hosp_R_conf);
@@ -3029,6 +3032,8 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.new_I_ICU_D_unconf = std::vector<real_t>(internal.dim_new_I_ICU_D_unconf);
   internal.new_I_ICU_R_conf = std::vector<real_t>(internal.dim_new_I_ICU_R_conf);
   internal.new_I_ICU_R_unconf = std::vector<real_t>(internal.dim_new_I_ICU_R_unconf);
+  internal.new_I_ILI = std::vector<real_t>(internal.dim_new_I_ILI);
+  internal.new_I_mild = std::vector<real_t>(internal.dim_new_I_mild);
   internal.new_I_triage_D_conf = std::vector<real_t>(internal.dim_new_I_triage_D_conf);
   internal.new_I_triage_D_unconf = std::vector<real_t>(internal.dim_new_I_triage_D_unconf);
   internal.new_I_triage_R_conf = std::vector<real_t>(internal.dim_new_I_triage_R_conf);
@@ -3180,26 +3185,26 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
     }
   }
   internal.m = user_get_array_fixed<real_t, 2>(user, "m", internal.m, {internal.dim_m_1, internal.dim_m_2}, NA_REAL, NA_REAL);
-  internal.offset_variable_E = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos;
-  internal.offset_variable_I_asympt = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E;
-  internal.offset_variable_I_comm_D = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI;
-  internal.offset_variable_I_hosp_D_conf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf;
-  internal.offset_variable_I_hosp_D_unconf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf;
-  internal.offset_variable_I_hosp_R_conf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf;
-  internal.offset_variable_I_hosp_R_unconf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf;
-  internal.offset_variable_I_ICU_D_conf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf + internal.dim_I_ICU_D_unconf;
-  internal.offset_variable_I_ICU_D_unconf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf;
-  internal.offset_variable_I_ICU_R_conf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf;
-  internal.offset_variable_I_ICU_R_unconf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf;
-  internal.offset_variable_I_ILI = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild;
-  internal.offset_variable_I_mild = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt;
-  internal.offset_variable_I_triage_D_conf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf;
-  internal.offset_variable_I_triage_D_unconf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf;
-  internal.offset_variable_I_triage_R_conf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf;
-  internal.offset_variable_I_triage_R_unconf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D;
-  internal.offset_variable_PCR_pos = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre;
-  internal.offset_variable_R_pre = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf;
-  internal.offset_variable_R_stepdown_conf = 13 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf;
+  internal.offset_variable_E = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos;
+  internal.offset_variable_I_asympt = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E;
+  internal.offset_variable_I_comm_D = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI;
+  internal.offset_variable_I_hosp_D_conf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf;
+  internal.offset_variable_I_hosp_D_unconf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf;
+  internal.offset_variable_I_hosp_R_conf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf;
+  internal.offset_variable_I_hosp_R_unconf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf;
+  internal.offset_variable_I_ICU_D_conf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf + internal.dim_I_ICU_D_unconf;
+  internal.offset_variable_I_ICU_D_unconf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf + internal.dim_I_ICU_R_conf;
+  internal.offset_variable_I_ICU_R_conf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf + internal.dim_I_ICU_R_unconf;
+  internal.offset_variable_I_ICU_R_unconf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf + internal.dim_I_triage_D_conf + internal.dim_I_hosp_R_unconf + internal.dim_I_hosp_R_conf + internal.dim_I_hosp_D_unconf + internal.dim_I_hosp_D_conf;
+  internal.offset_variable_I_ILI = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild;
+  internal.offset_variable_I_mild = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt;
+  internal.offset_variable_I_triage_D_conf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf + internal.dim_I_triage_D_unconf;
+  internal.offset_variable_I_triage_D_unconf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf + internal.dim_I_triage_R_conf;
+  internal.offset_variable_I_triage_R_conf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D + internal.dim_I_triage_R_unconf;
+  internal.offset_variable_I_triage_R_unconf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre + internal.dim_PCR_pos + internal.dim_E + internal.dim_I_asympt + internal.dim_I_mild + internal.dim_I_ILI + internal.dim_I_comm_D;
+  internal.offset_variable_PCR_pos = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf + internal.dim_R_pre;
+  internal.offset_variable_R_pre = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf + internal.dim_R_stepdown_conf;
+  internal.offset_variable_R_stepdown_conf = 14 + internal.dim_S + internal.dim_R_pos + internal.dim_R_neg + internal.dim_R + internal.dim_D_hosp + internal.dim_D_comm + internal.dim_cum_admit_by_age + internal.dim_N_tot + internal.dim_R_stepdown_unconf;
   for (int_t i = 1; i <= internal.dim_p_R_pre_1; ++i) {
     for (int_t j = 1; j <= internal.dim_p_R_pre_2; ++j) {
       internal.p_R_pre[i - 1 + internal.dim_p_R_pre_1 * (j - 1)] = 1 - std::exp(- internal.gamma_R_pre[j - 1] * internal.dt);
@@ -3228,8 +3233,8 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
 }
 template <>
 cpp11::sexp dust_info<carehomes>(const carehomes::init_t& internal) {
-  cpp11::writable::strings nms({"time", "cum_infections", "cum_admit_conf", "cum_new_conf", "beta_out", "N_tot2", "I_ICU_tot", "general_tot", "hosp_tot", "D_hosp_tot", "D_comm_tot", "D_tot", "prob_pos", "S", "R_pos", "R_neg", "R", "D_hosp", "D_comm", "cum_admit_by_age", "N_tot", "R_stepdown_unconf", "R_stepdown_conf", "R_pre", "PCR_pos", "E", "I_asympt", "I_mild", "I_ILI", "I_comm_D", "I_triage_R_unconf", "I_triage_R_conf", "I_triage_D_unconf", "I_triage_D_conf", "I_hosp_R_unconf", "I_hosp_R_conf", "I_hosp_D_unconf", "I_hosp_D_conf", "I_ICU_R_unconf", "I_ICU_R_conf", "I_ICU_D_unconf", "I_ICU_D_conf"});
-  cpp11::writable::list dim(42);
+  cpp11::writable::strings nms({"time", "cum_infections", "cum_admit_conf", "cum_new_conf", "beta_out", "N_tot2", "I_ICU_tot", "general_tot", "hosp_tot", "D_hosp_tot", "D_comm_tot", "D_tot", "sero_prob_pos", "pillar2_prob_pos", "S", "R_pos", "R_neg", "R", "D_hosp", "D_comm", "cum_admit_by_age", "N_tot", "R_stepdown_unconf", "R_stepdown_conf", "R_pre", "PCR_pos", "E", "I_asympt", "I_mild", "I_ILI", "I_comm_D", "I_triage_R_unconf", "I_triage_R_conf", "I_triage_D_unconf", "I_triage_D_conf", "I_hosp_R_unconf", "I_hosp_R_conf", "I_hosp_D_unconf", "I_hosp_D_conf", "I_ICU_R_unconf", "I_ICU_R_conf", "I_ICU_D_unconf", "I_ICU_D_conf"});
+  cpp11::writable::list dim(43);
   dim[0] = cpp11::writable::integers({1});
   dim[1] = cpp11::writable::integers({1});
   dim[2] = cpp11::writable::integers({1});
@@ -3243,37 +3248,38 @@ cpp11::sexp dust_info<carehomes>(const carehomes::init_t& internal) {
   dim[10] = cpp11::writable::integers({1});
   dim[11] = cpp11::writable::integers({1});
   dim[12] = cpp11::writable::integers({1});
-  dim[13] = cpp11::writable::integers({internal.dim_S});
-  dim[14] = cpp11::writable::integers({internal.dim_R_pos});
-  dim[15] = cpp11::writable::integers({internal.dim_R_neg});
-  dim[16] = cpp11::writable::integers({internal.dim_R});
-  dim[17] = cpp11::writable::integers({internal.dim_D_hosp});
-  dim[18] = cpp11::writable::integers({internal.dim_D_comm});
-  dim[19] = cpp11::writable::integers({internal.dim_cum_admit_by_age});
-  dim[20] = cpp11::writable::integers({internal.dim_N_tot});
-  dim[21] = cpp11::writable::integers({internal.dim_R_stepdown_unconf_1, internal.dim_R_stepdown_unconf_2});
-  dim[22] = cpp11::writable::integers({internal.dim_R_stepdown_conf_1, internal.dim_R_stepdown_conf_2});
-  dim[23] = cpp11::writable::integers({internal.dim_R_pre_1, internal.dim_R_pre_2});
-  dim[24] = cpp11::writable::integers({internal.dim_PCR_pos_1, internal.dim_PCR_pos_2});
-  dim[25] = cpp11::writable::integers({internal.dim_E_1, internal.dim_E_2, internal.dim_E_3});
-  dim[26] = cpp11::writable::integers({internal.dim_I_asympt_1, internal.dim_I_asympt_2, internal.dim_I_asympt_3});
-  dim[27] = cpp11::writable::integers({internal.dim_I_mild_1, internal.dim_I_mild_2, internal.dim_I_mild_3});
-  dim[28] = cpp11::writable::integers({internal.dim_I_ILI_1, internal.dim_I_ILI_2, internal.dim_I_ILI_3});
-  dim[29] = cpp11::writable::integers({internal.dim_I_comm_D_1, internal.dim_I_comm_D_2, internal.dim_I_comm_D_3});
-  dim[30] = cpp11::writable::integers({internal.dim_I_triage_R_unconf_1, internal.dim_I_triage_R_unconf_2, internal.dim_I_triage_R_unconf_3});
-  dim[31] = cpp11::writable::integers({internal.dim_I_triage_R_conf_1, internal.dim_I_triage_R_conf_2, internal.dim_I_triage_R_conf_3});
-  dim[32] = cpp11::writable::integers({internal.dim_I_triage_D_unconf_1, internal.dim_I_triage_D_unconf_2, internal.dim_I_triage_D_unconf_3});
-  dim[33] = cpp11::writable::integers({internal.dim_I_triage_D_conf_1, internal.dim_I_triage_D_conf_2, internal.dim_I_triage_D_conf_3});
-  dim[34] = cpp11::writable::integers({internal.dim_I_hosp_R_unconf_1, internal.dim_I_hosp_R_unconf_2, internal.dim_I_hosp_R_unconf_3});
-  dim[35] = cpp11::writable::integers({internal.dim_I_hosp_R_conf_1, internal.dim_I_hosp_R_conf_2, internal.dim_I_hosp_R_conf_3});
-  dim[36] = cpp11::writable::integers({internal.dim_I_hosp_D_unconf_1, internal.dim_I_hosp_D_unconf_2, internal.dim_I_hosp_D_unconf_3});
-  dim[37] = cpp11::writable::integers({internal.dim_I_hosp_D_conf_1, internal.dim_I_hosp_D_conf_2, internal.dim_I_hosp_D_conf_3});
-  dim[38] = cpp11::writable::integers({internal.dim_I_ICU_R_unconf_1, internal.dim_I_ICU_R_unconf_2, internal.dim_I_ICU_R_unconf_3});
-  dim[39] = cpp11::writable::integers({internal.dim_I_ICU_R_conf_1, internal.dim_I_ICU_R_conf_2, internal.dim_I_ICU_R_conf_3});
-  dim[40] = cpp11::writable::integers({internal.dim_I_ICU_D_unconf_1, internal.dim_I_ICU_D_unconf_2, internal.dim_I_ICU_D_unconf_3});
-  dim[41] = cpp11::writable::integers({internal.dim_I_ICU_D_conf_1, internal.dim_I_ICU_D_conf_2, internal.dim_I_ICU_D_conf_3});
+  dim[13] = cpp11::writable::integers({1});
+  dim[14] = cpp11::writable::integers({internal.dim_S});
+  dim[15] = cpp11::writable::integers({internal.dim_R_pos});
+  dim[16] = cpp11::writable::integers({internal.dim_R_neg});
+  dim[17] = cpp11::writable::integers({internal.dim_R});
+  dim[18] = cpp11::writable::integers({internal.dim_D_hosp});
+  dim[19] = cpp11::writable::integers({internal.dim_D_comm});
+  dim[20] = cpp11::writable::integers({internal.dim_cum_admit_by_age});
+  dim[21] = cpp11::writable::integers({internal.dim_N_tot});
+  dim[22] = cpp11::writable::integers({internal.dim_R_stepdown_unconf_1, internal.dim_R_stepdown_unconf_2});
+  dim[23] = cpp11::writable::integers({internal.dim_R_stepdown_conf_1, internal.dim_R_stepdown_conf_2});
+  dim[24] = cpp11::writable::integers({internal.dim_R_pre_1, internal.dim_R_pre_2});
+  dim[25] = cpp11::writable::integers({internal.dim_PCR_pos_1, internal.dim_PCR_pos_2});
+  dim[26] = cpp11::writable::integers({internal.dim_E_1, internal.dim_E_2, internal.dim_E_3});
+  dim[27] = cpp11::writable::integers({internal.dim_I_asympt_1, internal.dim_I_asympt_2, internal.dim_I_asympt_3});
+  dim[28] = cpp11::writable::integers({internal.dim_I_mild_1, internal.dim_I_mild_2, internal.dim_I_mild_3});
+  dim[29] = cpp11::writable::integers({internal.dim_I_ILI_1, internal.dim_I_ILI_2, internal.dim_I_ILI_3});
+  dim[30] = cpp11::writable::integers({internal.dim_I_comm_D_1, internal.dim_I_comm_D_2, internal.dim_I_comm_D_3});
+  dim[31] = cpp11::writable::integers({internal.dim_I_triage_R_unconf_1, internal.dim_I_triage_R_unconf_2, internal.dim_I_triage_R_unconf_3});
+  dim[32] = cpp11::writable::integers({internal.dim_I_triage_R_conf_1, internal.dim_I_triage_R_conf_2, internal.dim_I_triage_R_conf_3});
+  dim[33] = cpp11::writable::integers({internal.dim_I_triage_D_unconf_1, internal.dim_I_triage_D_unconf_2, internal.dim_I_triage_D_unconf_3});
+  dim[34] = cpp11::writable::integers({internal.dim_I_triage_D_conf_1, internal.dim_I_triage_D_conf_2, internal.dim_I_triage_D_conf_3});
+  dim[35] = cpp11::writable::integers({internal.dim_I_hosp_R_unconf_1, internal.dim_I_hosp_R_unconf_2, internal.dim_I_hosp_R_unconf_3});
+  dim[36] = cpp11::writable::integers({internal.dim_I_hosp_R_conf_1, internal.dim_I_hosp_R_conf_2, internal.dim_I_hosp_R_conf_3});
+  dim[37] = cpp11::writable::integers({internal.dim_I_hosp_D_unconf_1, internal.dim_I_hosp_D_unconf_2, internal.dim_I_hosp_D_unconf_3});
+  dim[38] = cpp11::writable::integers({internal.dim_I_hosp_D_conf_1, internal.dim_I_hosp_D_conf_2, internal.dim_I_hosp_D_conf_3});
+  dim[39] = cpp11::writable::integers({internal.dim_I_ICU_R_unconf_1, internal.dim_I_ICU_R_unconf_2, internal.dim_I_ICU_R_unconf_3});
+  dim[40] = cpp11::writable::integers({internal.dim_I_ICU_R_conf_1, internal.dim_I_ICU_R_conf_2, internal.dim_I_ICU_R_conf_3});
+  dim[41] = cpp11::writable::integers({internal.dim_I_ICU_D_unconf_1, internal.dim_I_ICU_D_unconf_2, internal.dim_I_ICU_D_unconf_3});
+  dim[42] = cpp11::writable::integers({internal.dim_I_ICU_D_conf_1, internal.dim_I_ICU_D_conf_2, internal.dim_I_ICU_D_conf_3});
   dim.names() = nms;
-  cpp11::writable::list index(42);
+  cpp11::writable::list index(43);
   index[0] = cpp11::writable::integers({1});
   index[1] = cpp11::writable::integers({2});
   index[2] = cpp11::writable::integers({3});
@@ -3287,35 +3293,36 @@ cpp11::sexp dust_info<carehomes>(const carehomes::init_t& internal) {
   index[10] = cpp11::writable::integers({11});
   index[11] = cpp11::writable::integers({12});
   index[12] = cpp11::writable::integers({13});
-  index[13] = integer_sequence(14, internal.dim_S);
-  index[14] = integer_sequence(internal.offset_variable_R_pos + 1, internal.dim_R_pos);
-  index[15] = integer_sequence(internal.offset_variable_R_neg + 1, internal.dim_R_neg);
-  index[16] = integer_sequence(internal.offset_variable_R + 1, internal.dim_R);
-  index[17] = integer_sequence(internal.offset_variable_D_hosp + 1, internal.dim_D_hosp);
-  index[18] = integer_sequence(internal.offset_variable_D_comm + 1, internal.dim_D_comm);
-  index[19] = integer_sequence(internal.offset_variable_cum_admit_by_age + 1, internal.dim_cum_admit_by_age);
-  index[20] = integer_sequence(internal.offset_variable_N_tot + 1, internal.dim_N_tot);
-  index[21] = integer_sequence(internal.offset_variable_R_stepdown_unconf + 1, internal.dim_R_stepdown_unconf);
-  index[22] = integer_sequence(internal.offset_variable_R_stepdown_conf + 1, internal.dim_R_stepdown_conf);
-  index[23] = integer_sequence(internal.offset_variable_R_pre + 1, internal.dim_R_pre);
-  index[24] = integer_sequence(internal.offset_variable_PCR_pos + 1, internal.dim_PCR_pos);
-  index[25] = integer_sequence(internal.offset_variable_E + 1, internal.dim_E);
-  index[26] = integer_sequence(internal.offset_variable_I_asympt + 1, internal.dim_I_asympt);
-  index[27] = integer_sequence(internal.offset_variable_I_mild + 1, internal.dim_I_mild);
-  index[28] = integer_sequence(internal.offset_variable_I_ILI + 1, internal.dim_I_ILI);
-  index[29] = integer_sequence(internal.offset_variable_I_comm_D + 1, internal.dim_I_comm_D);
-  index[30] = integer_sequence(internal.offset_variable_I_triage_R_unconf + 1, internal.dim_I_triage_R_unconf);
-  index[31] = integer_sequence(internal.offset_variable_I_triage_R_conf + 1, internal.dim_I_triage_R_conf);
-  index[32] = integer_sequence(internal.offset_variable_I_triage_D_unconf + 1, internal.dim_I_triage_D_unconf);
-  index[33] = integer_sequence(internal.offset_variable_I_triage_D_conf + 1, internal.dim_I_triage_D_conf);
-  index[34] = integer_sequence(internal.offset_variable_I_hosp_R_unconf + 1, internal.dim_I_hosp_R_unconf);
-  index[35] = integer_sequence(internal.offset_variable_I_hosp_R_conf + 1, internal.dim_I_hosp_R_conf);
-  index[36] = integer_sequence(internal.offset_variable_I_hosp_D_unconf + 1, internal.dim_I_hosp_D_unconf);
-  index[37] = integer_sequence(internal.offset_variable_I_hosp_D_conf + 1, internal.dim_I_hosp_D_conf);
-  index[38] = integer_sequence(internal.offset_variable_I_ICU_R_unconf + 1, internal.dim_I_ICU_R_unconf);
-  index[39] = integer_sequence(internal.offset_variable_I_ICU_R_conf + 1, internal.dim_I_ICU_R_conf);
-  index[40] = integer_sequence(internal.offset_variable_I_ICU_D_unconf + 1, internal.dim_I_ICU_D_unconf);
-  index[41] = integer_sequence(internal.offset_variable_I_ICU_D_conf + 1, internal.dim_I_ICU_D_conf);
+  index[13] = cpp11::writable::integers({14});
+  index[14] = integer_sequence(15, internal.dim_S);
+  index[15] = integer_sequence(internal.offset_variable_R_pos + 1, internal.dim_R_pos);
+  index[16] = integer_sequence(internal.offset_variable_R_neg + 1, internal.dim_R_neg);
+  index[17] = integer_sequence(internal.offset_variable_R + 1, internal.dim_R);
+  index[18] = integer_sequence(internal.offset_variable_D_hosp + 1, internal.dim_D_hosp);
+  index[19] = integer_sequence(internal.offset_variable_D_comm + 1, internal.dim_D_comm);
+  index[20] = integer_sequence(internal.offset_variable_cum_admit_by_age + 1, internal.dim_cum_admit_by_age);
+  index[21] = integer_sequence(internal.offset_variable_N_tot + 1, internal.dim_N_tot);
+  index[22] = integer_sequence(internal.offset_variable_R_stepdown_unconf + 1, internal.dim_R_stepdown_unconf);
+  index[23] = integer_sequence(internal.offset_variable_R_stepdown_conf + 1, internal.dim_R_stepdown_conf);
+  index[24] = integer_sequence(internal.offset_variable_R_pre + 1, internal.dim_R_pre);
+  index[25] = integer_sequence(internal.offset_variable_PCR_pos + 1, internal.dim_PCR_pos);
+  index[26] = integer_sequence(internal.offset_variable_E + 1, internal.dim_E);
+  index[27] = integer_sequence(internal.offset_variable_I_asympt + 1, internal.dim_I_asympt);
+  index[28] = integer_sequence(internal.offset_variable_I_mild + 1, internal.dim_I_mild);
+  index[29] = integer_sequence(internal.offset_variable_I_ILI + 1, internal.dim_I_ILI);
+  index[30] = integer_sequence(internal.offset_variable_I_comm_D + 1, internal.dim_I_comm_D);
+  index[31] = integer_sequence(internal.offset_variable_I_triage_R_unconf + 1, internal.dim_I_triage_R_unconf);
+  index[32] = integer_sequence(internal.offset_variable_I_triage_R_conf + 1, internal.dim_I_triage_R_conf);
+  index[33] = integer_sequence(internal.offset_variable_I_triage_D_unconf + 1, internal.dim_I_triage_D_unconf);
+  index[34] = integer_sequence(internal.offset_variable_I_triage_D_conf + 1, internal.dim_I_triage_D_conf);
+  index[35] = integer_sequence(internal.offset_variable_I_hosp_R_unconf + 1, internal.dim_I_hosp_R_unconf);
+  index[36] = integer_sequence(internal.offset_variable_I_hosp_R_conf + 1, internal.dim_I_hosp_R_conf);
+  index[37] = integer_sequence(internal.offset_variable_I_hosp_D_unconf + 1, internal.dim_I_hosp_D_unconf);
+  index[38] = integer_sequence(internal.offset_variable_I_hosp_D_conf + 1, internal.dim_I_hosp_D_conf);
+  index[39] = integer_sequence(internal.offset_variable_I_ICU_R_unconf + 1, internal.dim_I_ICU_R_unconf);
+  index[40] = integer_sequence(internal.offset_variable_I_ICU_R_conf + 1, internal.dim_I_ICU_R_conf);
+  index[41] = integer_sequence(internal.offset_variable_I_ICU_D_unconf + 1, internal.dim_I_ICU_D_unconf);
+  index[42] = integer_sequence(internal.offset_variable_I_ICU_D_conf + 1, internal.dim_I_ICU_D_conf);
   index.names() = nms;
   size_t len = internal.offset_variable_I_ICU_D_conf + internal.dim_I_ICU_D_conf;
   using namespace cpp11::literals;

--- a/tests/testthat/test-carehomes-support.R
+++ b/tests/testthat/test-carehomes-support.R
@@ -234,7 +234,7 @@ test_that("carehomes_compare combines likelihood correctly", {
     observed[nms] <- NA_real_
     observed
   }
-  
+
   ## This function is more complicated to test than the basic model
   ## because it's not a simple sum
   nms_sero <- c("npos_15_64", "ntot_15_64")

--- a/tests/testthat/test-carehomes.R
+++ b/tests/testthat/test-carehomes.R
@@ -10,7 +10,7 @@ test_that("can run the carehomes model", {
 
   mod$set_index(carehomes_index(mod$info())$run)
   res <- mod$run(end)
-  
+
   expected <- rbind(
     icu = c(8, 8, 3, 18, 6),
     general = c(52, 67, 20, 67, 19),

--- a/tests/testthat/test-carehomes.R
+++ b/tests/testthat/test-carehomes.R
@@ -10,8 +10,7 @@ test_that("can run the carehomes model", {
 
   mod$set_index(carehomes_index(mod$info())$run)
   res <- mod$run(end)
-  saveRDS(res, "res.rds")
-
+  
   expected <- rbind(
     icu = c(8, 8, 3, 18, 6),
     general = c(52, 67, 20, 67, 19),

--- a/tests/testthat/test-carehomes.R
+++ b/tests/testthat/test-carehomes.R
@@ -10,6 +10,7 @@ test_that("can run the carehomes model", {
 
   mod$set_index(carehomes_index(mod$info())$run)
   res <- mod$run(end)
+  saveRDS(res, "res.rds")
 
   expected <- rbind(
     icu = c(8, 8, 3, 18, 6),
@@ -18,8 +19,11 @@ test_that("can run the carehomes model", {
     deaths_hosp = c(305649, 305638, 305740, 306023, 306163),
     admitted = c(151360, 150612, 151197, 151101, 150386),
     new = c(484244, 483918, 483997, 484935, 484355),
-    prob_pos = c(0.723860522215455, 0.723923883973212, 0.724058180618437,
-                 0.723865988088634, 0.723862084297041))
+    sero_prob_pos = c(0.723860522215455, 0.723923883973212, 0.724058180618437,
+                 0.723865988088634, 0.723862084297041),
+    pillar2_prob_pos = c(1.4212883915311252e-06, 2.0964003775084099e-06,
+                         4.7968483214175475e-07, 2.8958750977446676e-06,
+                         5.6851535661245008e-07))
   expect_equal(res, expected)
 })
 
@@ -38,6 +42,8 @@ test_that("can run the particle filter on the model", {
   data$new <- NA
   data$npos_15_64 <- NA
   data$ntot_15_64 <- NA
+  data$pillar2_pos <- NA
+  data$pillar2_tot <- NA
 
   pf <- carehomes_particle_filter(data, 10)
   expect_s3_class(pf, "particle_filter")


### PR DESCRIPTION
This adds Pillar 2 testing to the carehomes model. Now with two kinds of positivity testing in the compare, I have renamed 'prob_pos' to 'sero_prob_pos' to make it clearer what kind of testing that one applies to.