### PR TITLE
make sure pillar2 contributes to log-likelihood

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid2
 Title: SIR Model for COVID-19
-Version: 0.5.15
+Version: 0.5.16
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/carehomes.R
+++ b/R/carehomes.R
@@ -250,7 +250,7 @@ carehomes_compare <- function(state, prev_state, observed, pars) {
                          pars$phi_pillar2 * model_pillar2_prob_pos)
 
   ll_icu + ll_general + ll_deaths_hosp + ll_deaths_comm + ll_deaths +
-    ll_admitted + ll_new + ll_serology
+    ll_admitted + ll_new + ll_serology + ll_pillar2
 }
 
 

--- a/tests/testthat/test-carehomes-support.R
+++ b/tests/testthat/test-carehomes-support.R
@@ -248,7 +248,6 @@ test_that("carehomes_compare combines likelihood correctly", {
   ## Extremely light testing, though this has already flushed out some
   ## issues
   expect_true(all(lengths(ll_parts) == 6))
-  expect_true
   expect_equal(
     carehomes_compare(state, prev_state, observed, pars),
     rowSums(do.call(cbind, ll_parts)))

--- a/tests/testthat/test-carehomes-support.R
+++ b/tests/testthat/test-carehomes-support.R
@@ -244,7 +244,6 @@ test_that("carehomes_compare combines likelihood correctly", {
 
   ll_parts <- lapply(parts, function(x)
     carehomes_compare(state, prev_state, observed_keep(x), pars))
-  saveRDS(ll_parts,"res.rds")
 
   ## Extremely light testing, though this has already flushed out some
   ## issues
@@ -253,11 +252,11 @@ test_that("carehomes_compare combines likelihood correctly", {
   expect_equal(
     carehomes_compare(state, prev_state, observed, pars),
     rowSums(do.call(cbind, ll_parts)))
-  
+
   ## Test that there are non-zero values for each log-likelihood part.
   ## This helps make sure all parts contribute to the log-likelihood.
   expect_true(all(sapply(ll_parts, function(x) any(x != 0))))
-  
+
 })
 
 

--- a/tests/testthat/test-carehomes-support.R
+++ b/tests/testthat/test-carehomes-support.R
@@ -244,13 +244,20 @@ test_that("carehomes_compare combines likelihood correctly", {
 
   ll_parts <- lapply(parts, function(x)
     carehomes_compare(state, prev_state, observed_keep(x), pars))
+  saveRDS(ll_parts,"res.rds")
 
   ## Extremely light testing, though this has already flushed out some
   ## issues
   expect_true(all(lengths(ll_parts) == 6))
+  expect_true
   expect_equal(
     carehomes_compare(state, prev_state, observed, pars),
     rowSums(do.call(cbind, ll_parts)))
+  
+  ## Test that there are non-zero values for each log-likelihood part.
+  ## This helps make sure all parts contribute to the log-likelihood.
+  expect_true(all(sapply(ll_parts, function(x) any(x != 0))))
+  
 })
 
 


### PR DESCRIPTION
`ll_pillar2` was not added into the output of the carehomes compare function, so the pillar 2 data wasn't being fitted at all. This fixes that, and I've added to the tests to prevent this happening with future data streams.