### PR TITLE
p_sensitivity now used explicitly in sero calculation

### DIFF
--- a/R/carehomes.R
+++ b/R/carehomes.R
@@ -26,6 +26,8 @@ NULL
 ##'
 ##' @param p_specificity Specificity of the serology test
 ##'
+##' @param p_sensitivity Sensitivity of the serology test
+##'
 ##' @param progression Progression data
 ##'
 ##' @param eps Change in contact rate for carehome residents
@@ -55,6 +57,7 @@ carehomes_parameters <- function(start_date, region,
                                  severity = NULL,
                                  p_death_carehome = 0.7,
                                  p_specificity = 0.9,
+                                 p_sensitivity = 1,
                                  progression = NULL,
                                  eps = 0.1,
                                  C_1 = 4e-5,
@@ -121,8 +124,9 @@ carehomes_parameters <- function(start_date, region,
   ## 15 to 64 year olds.
   ret$N_tot_15_64 <- sum(ret$N_tot[4:13])
 
-  ## Specificity for serology tests
+  ## Specificity and sensitivity for serology tests
   ret$p_specificity <- p_specificity
+  ret$p_sensitivity <- p_sensitivity
 
   ## Specificity and sensitivity for Pillar 2 testing
   ret$pillar2_specificity <- pillar2_specificity

--- a/inst/dust/carehomes.cpp
+++ b/inst/dust/carehomes.cpp
@@ -755,6 +755,7 @@ public:
     real_t p_R_pre_1;
     real_t p_R_stepdown;
     std::vector<real_t> p_SE;
+    real_t p_sensitivity;
     std::vector<real_t> p_seroconversion;
     real_t p_specificity;
     std::vector<real_t> p_sympt_ILI;
@@ -1710,6 +1711,7 @@ public:
         state_next[internal.offset_variable_R_stepdown_unconf + i - 1 + internal.dim_R_stepdown_unconf_1 * (j - 1)] = internal.new_R_stepdown_unconf[internal.dim_new_R_stepdown_unconf_1 * (j - 1) + i - 1];
       }
     }
+    state_next[12] = internal.p_sensitivity * odin_sum1(internal.new_R_pos.data(), 3, 13) / (real_t) internal.N_tot_15_64 + (1 - internal.p_specificity) * (1 - odin_sum1(internal.new_R_pos.data(), 3, 13) / (real_t) internal.N_tot_15_64);
     for (int_t i = 1; i <= internal.dim_n_hosp_non_ICU_1; ++i) {
       for (int_t j = 1; j <= internal.dim_n_hosp_non_ICU_2; ++j) {
         internal.n_hosp_non_ICU[i - 1 + internal.dim_n_hosp_non_ICU_1 * (j - 1)] = internal.n_ILI_to_hosp[internal.dim_n_ILI_to_hosp_1 * (j - 1) + i - 1] - internal.n_ILI_to_triage[internal.dim_n_ILI_to_triage_1 * (j - 1) + i - 1];
@@ -1748,7 +1750,6 @@ public:
     for (int_t i = 1; i <= internal.dim_R_neg; ++i) {
       state_next[internal.offset_variable_R_neg + i - 1] = internal.new_R_neg[i - 1];
     }
-    state_next[12] = odin_sum1(internal.new_R_pos.data(), 3, 13) / (real_t) internal.N_tot_15_64 + (1 - internal.p_specificity) * (1 - (odin_sum2(internal.new_R_pre.data(), 3, 13, 0, internal.dim_new_R_pre_2, internal.dim_new_R_pre_1) + odin_sum1(internal.new_R_neg.data(), 3, 13) + odin_sum1(internal.new_R_pos.data(), 3, 13)) / (real_t) internal.N_tot_15_64);
     for (int_t i = 1; i <= internal.dim_aux_EE_1; ++i) {
       int_t j = 1;
       int_t k = 1;
@@ -2308,6 +2309,7 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.ICU_transmission = NA_REAL;
   internal.N_age = NA_INTEGER;
   internal.N_tot_15_64 = NA_REAL;
+  internal.p_sensitivity = NA_REAL;
   internal.p_specificity = NA_REAL;
   internal.s_asympt = NA_INTEGER;
   internal.s_comm_D = NA_INTEGER;
@@ -2381,6 +2383,7 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.p_ICU_hosp_step = user_get_array_variable<real_t, 1>(user, "p_ICU_hosp_step", internal.p_ICU_hosp_step, dim_p_ICU_hosp_step, NA_REAL, NA_REAL);
   internal.dim_p_ICU_hosp_step = internal.p_ICU_hosp_step.size();
   internal.p_R_pre_1 = user_get_scalar<real_t>(user, "p_R_pre_1", internal.p_R_pre_1, NA_REAL, NA_REAL);
+  internal.p_sensitivity = user_get_scalar<real_t>(user, "p_sensitivity", internal.p_sensitivity, NA_REAL, NA_REAL);
   internal.p_specificity = user_get_scalar<real_t>(user, "p_specificity", internal.p_specificity, NA_REAL, NA_REAL);
   internal.s_asympt = user_get_scalar<int_t>(user, "s_asympt", internal.s_asympt, NA_REAL, NA_REAL);
   internal.s_comm_D = user_get_scalar<int_t>(user, "s_comm_D", internal.s_comm_D, NA_REAL, NA_REAL);

--- a/inst/odin/carehomes.R
+++ b/inst/odin/carehomes.R
@@ -836,6 +836,7 @@ initial(D_tot) <- 0
 update(D_tot) <- new_D_hosp_tot + new_D_comm_tot
 
 p_specificity <- user()
+p_sensitivity <- user()
 N_tot_15_64 <- user()
 
 initial(sero_prob_pos) <- 0
@@ -855,10 +856,8 @@ initial(sero_prob_pos) <- 0
 ##
 ## NOTE: the R_pre sum sweeps out the second compartment used to
 ## model the mixture of exponentials.
-update(sero_prob_pos) <- sum(new_R_pos[4:13]) / N_tot_15_64 +
-  (1 - p_specificity) *
-  (1 - (sum(new_R_pre[4:13, ]) +
-          sum(new_R_neg[4:13]) + sum(new_R_pos[4:13])) / N_tot_15_64)
+update(sero_prob_pos) <- p_sensitivity * sum(new_R_pos[4:13]) / N_tot_15_64 +
+  (1 - p_specificity) * (1 - sum(new_R_pos[4:13]) / N_tot_15_64)
 
 initial(cum_sympt_cases) <- 0
 update(cum_sympt_cases) <- cum_sympt_cases + sum(n_EI_mild) + sum(n_EI_ILI)

--- a/man/carehomes_parameters.Rd
+++ b/man/carehomes_parameters.Rd
@@ -12,6 +12,7 @@ carehomes_parameters(
   severity = NULL,
   p_death_carehome = 0.7,
   p_specificity = 0.9,
+  p_sensitivity = 1,
   progression = NULL,
   eps = 0.1,
   C_1 = 4e-05,
@@ -58,6 +59,8 @@ with the progression parameters.}
 (conditional on having an "inflenza-like-illness")}
 
 \item{p_specificity}{Specificity of the serology test}
+
+\item{p_sensitivity}{Sensitivity of the serology test}
 
 \item{progression}{Progression data}
 

--- a/src/carehomes.cpp
+++ b/src/carehomes.cpp
@@ -760,6 +760,7 @@ public:
     real_t p_R_pre_1;
     real_t p_R_stepdown;
     std::vector<real_t> p_SE;
+    real_t p_sensitivity;
     std::vector<real_t> p_seroconversion;
     real_t p_specificity;
     std::vector<real_t> p_sympt_ILI;
@@ -1715,6 +1716,7 @@ public:
         state_next[internal.offset_variable_R_stepdown_unconf + i - 1 + internal.dim_R_stepdown_unconf_1 * (j - 1)] = internal.new_R_stepdown_unconf[internal.dim_new_R_stepdown_unconf_1 * (j - 1) + i - 1];
       }
     }
+    state_next[12] = internal.p_sensitivity * odin_sum1(internal.new_R_pos.data(), 3, 13) / (real_t) internal.N_tot_15_64 + (1 - internal.p_specificity) * (1 - odin_sum1(internal.new_R_pos.data(), 3, 13) / (real_t) internal.N_tot_15_64);
     for (int_t i = 1; i <= internal.dim_n_hosp_non_ICU_1; ++i) {
       for (int_t j = 1; j <= internal.dim_n_hosp_non_ICU_2; ++j) {
         internal.n_hosp_non_ICU[i - 1 + internal.dim_n_hosp_non_ICU_1 * (j - 1)] = internal.n_ILI_to_hosp[internal.dim_n_ILI_to_hosp_1 * (j - 1) + i - 1] - internal.n_ILI_to_triage[internal.dim_n_ILI_to_triage_1 * (j - 1) + i - 1];
@@ -1753,7 +1755,6 @@ public:
     for (int_t i = 1; i <= internal.dim_R_neg; ++i) {
       state_next[internal.offset_variable_R_neg + i - 1] = internal.new_R_neg[i - 1];
     }
-    state_next[12] = odin_sum1(internal.new_R_pos.data(), 3, 13) / (real_t) internal.N_tot_15_64 + (1 - internal.p_specificity) * (1 - (odin_sum2(internal.new_R_pre.data(), 3, 13, 0, internal.dim_new_R_pre_2, internal.dim_new_R_pre_1) + odin_sum1(internal.new_R_neg.data(), 3, 13) + odin_sum1(internal.new_R_pos.data(), 3, 13)) / (real_t) internal.N_tot_15_64);
     for (int_t i = 1; i <= internal.dim_aux_EE_1; ++i) {
       int_t j = 1;
       int_t k = 1;
@@ -2313,6 +2314,7 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.ICU_transmission = NA_REAL;
   internal.N_age = NA_INTEGER;
   internal.N_tot_15_64 = NA_REAL;
+  internal.p_sensitivity = NA_REAL;
   internal.p_specificity = NA_REAL;
   internal.s_asympt = NA_INTEGER;
   internal.s_comm_D = NA_INTEGER;
@@ -2386,6 +2388,7 @@ carehomes::init_t dust_data<carehomes>(cpp11::list user) {
   internal.p_ICU_hosp_step = user_get_array_variable<real_t, 1>(user, "p_ICU_hosp_step", internal.p_ICU_hosp_step, dim_p_ICU_hosp_step, NA_REAL, NA_REAL);
   internal.dim_p_ICU_hosp_step = internal.p_ICU_hosp_step.size();
   internal.p_R_pre_1 = user_get_scalar<real_t>(user, "p_R_pre_1", internal.p_R_pre_1, NA_REAL, NA_REAL);
+  internal.p_sensitivity = user_get_scalar<real_t>(user, "p_sensitivity", internal.p_sensitivity, NA_REAL, NA_REAL);
   internal.p_specificity = user_get_scalar<real_t>(user, "p_specificity", internal.p_specificity, NA_REAL, NA_REAL);
   internal.s_asympt = user_get_scalar<int_t>(user, "s_asympt", internal.s_asympt, NA_REAL, NA_REAL);
   internal.s_comm_D = user_get_scalar<int_t>(user, "s_comm_D", internal.s_comm_D, NA_REAL, NA_REAL);

--- a/tests/testthat/test-carehomes-support.R
+++ b/tests/testthat/test-carehomes-support.R
@@ -53,7 +53,7 @@ test_that("carehomes_parameters returns a list of parameters", {
   expect_setequal(
     extra,
     c("N_tot", "carehome_beds", "carehome_residents", "carehome_workers",
-      "p_specificity", "N_tot_15_64", "pillar2_specificity",
+      "p_specificity", "p_sensitivity", "N_tot_15_64", "pillar2_specificity",
       "pillar2_sensitivity", "prop_noncovid_sympt", "psi_death_ICU",
       "p_death_ICU_step", "psi_death_hosp_D", "p_death_hosp_D_step",
       "psi_hosp_ILI", "p_hosp_ILI_step", "psi_death_comm",

--- a/tests/testthat/test-carehomes.R
+++ b/tests/testthat/test-carehomes.R
@@ -10,7 +10,7 @@ test_that("can run the carehomes model", {
 
   mod$set_index(carehomes_index(mod$info())$run)
   res <- mod$run(end)
-saveRDS(res,"res.rds")
+
   expected <- rbind(
     icu = c(8, 8, 3, 18, 6),
     general = c(52, 67, 20, 67, 19),

--- a/tests/testthat/test-carehomes.R
+++ b/tests/testthat/test-carehomes.R
@@ -10,7 +10,7 @@ test_that("can run the carehomes model", {
 
   mod$set_index(carehomes_index(mod$info())$run)
   res <- mod$run(end)
-
+saveRDS(res,"res.rds")
   expected <- rbind(
     icu = c(8, 8, 3, 18, 6),
     general = c(52, 67, 20, 67, 19),
@@ -18,8 +18,8 @@ test_that("can run the carehomes model", {
     deaths_hosp = c(305649, 305638, 305740, 306023, 306163),
     admitted = c(151360, 150612, 151197, 151101, 150386),
     new = c(484244, 483918, 483997, 484935, 484355),
-    sero_prob_pos = c(0.723860522215455, 0.723923883973212, 0.724058180618437,
-                 0.723865988088634, 0.723862084297041),
+    sero_prob_pos = c(0.7393342623, 0.7393961156, 0.7395169242,
+                      0.7393339826, 0.7393328386),
     sympt_cases = c(30885159, 30883639, 30887886, 30874524, 30871135))
   expect_equal(res, expected)
 })


### PR DESCRIPTION
This changes the `sero_prob_pos` calculation so that sensitivity is now included explicitly, rather than including it implicitly within `p_seroconversion`.